### PR TITLE
Adds argument allowing users to specify their clientID and issuer

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func run() int {
 		providerArg := loginCmd.String("provider", "", "Specify the issuer and client ID to use for OpenID Connect provider. Format is: <issuer>,<client_id> or <issuer>,<client_id>,<client_secret>")
 
 		if err := loginCmd.Parse(os.Args[2:]); err != nil {
-			log.Println("ERROR parsing args:", err)
+			fmt.Println("ERROR parsing args:", err)
 			return 1
 		}
 
@@ -103,6 +103,8 @@ func run() int {
 				log.SetOutput(multiWriter)
 				log.Printf("Failed to open log for writing: %v \n", err)
 			}
+		} else {
+			log.SetOutput(os.Stdout)
 		}
 
 		// If the user has supplied commandline arguments for the provider, use those instead of the web chooser
@@ -117,12 +119,12 @@ func run() int {
 			clientIDArg := parts[1]
 
 			if !strings.HasPrefix(issuerArg, "https://") {
-				log.Printf("ERROR Invalid provider issuer value. Expected issuer to start with 'https://' got %s \n", issuerArg)
+				log.Printf("ERROR Invalid provider issuer value. Expected issuer to start with 'https://' got (%s) \n", issuerArg)
 				return 1
 			}
 
 			if clientIDArg == "" {
-				log.Printf("ERROR Invalid provider client-ID value got %s \n", clientIDArg)
+				log.Printf("ERROR Invalid provider client-ID value got (%s) \n", clientIDArg)
 				return 1
 			}
 
@@ -135,7 +137,7 @@ func run() int {
 				}
 				clientSecretArg := parts[2]
 				if clientSecretArg == "" {
-					log.Printf("ERROR Invalid provider client secret value got %s \n", clientIDArg)
+					log.Printf("ERROR Invalid provider client secret value got (%s) \n", clientSecretArg)
 					return 1
 				}
 
@@ -274,12 +276,12 @@ func run() int {
 		// script to inject user entries into the policy file
 		//
 		// Example line to add a user:
-		// 		./opkssh add %p %e %i
-		//	%p The desired principal being assumed on the target (aka requested principal).
-		//  %e The email of the user to be added to the policy file.
-		//	%i The desired OpenID Provider for email, e.g. https://accounts.google.com.
+		// 		./opkssh add <Principal> <Email> <Issuer>
+		//	<Principal> The desired principal being assumed on the target (aka requested principal).
+		//  <Email> The email of the user to be added to the policy file.
+		//	<Issuer> The desired OpenID Provider for email, e.g. https://accounts.google.com.
 		if len(os.Args) != 5 {
-			fmt.Println("Invalid number of arguments for add, expected: `<Principal (TOKEN p)> <Email (TOKEN e)> <Issuer (TOKEN i)`")
+			fmt.Println("Invalid number of arguments for add, expected: `<Principal> <Email> <Issuer>`")
 			return 1
 		}
 		inputPrincipal := os.Args[2]

--- a/main_test.go
+++ b/main_test.go
@@ -18,7 +18,12 @@ package main
 
 import (
 	"errors"
+	"io"
+	"os"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsOpenSSHVersion8Dot1OrGreater(t *testing.T) {
@@ -110,6 +115,114 @@ func TestIsOpenSSHVersion8Dot1OrGreater(t *testing.T) {
 						gotErr.Error(), tt.wantErr.Error())
 				}
 			}
+		})
+	}
+}
+
+func RunCliAndCaptureResult(t *testing.T, args []string) (string, int) {
+	// Backup and defer restore of os.Args
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = args
+
+	// Capture output
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	os.Stderr = w
+
+	// Run the opkssh cli
+	exitCode := run()
+
+	// Restore stdout and stderr
+	w.Close()
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+
+	// Read captured output
+	var cmdOutput strings.Builder
+	_, err := io.Copy(&cmdOutput, r)
+	require.NoError(t, err)
+
+	return cmdOutput.String(), exitCode
+}
+
+func TestRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantOutput string
+		wantExit   int
+	}{
+		{
+			name:       "No arguments",
+			args:       []string{"opkssh"},
+			wantOutput: "OPKSSH (OpenPubkey SSH) CLI: command choices are: login, verify, and add",
+			wantExit:   1,
+		},
+		{
+			name:       "Version flag",
+			args:       []string{"opkssh", "--version"},
+			wantOutput: "unversioned",
+			wantExit:   0,
+		},
+		{
+			name:       "Unrecognized command",
+			args:       []string{"opkssh", "unknown"},
+			wantOutput: "ERROR! Unrecognized command: unknown",
+			wantExit:   1,
+		},
+		{
+			name:       "Add command with missing arguments",
+			args:       []string{"opkssh", "add"},
+			wantOutput: "Invalid number of arguments for add, expected: `<Principal> <Email> <Issuer>`",
+			wantExit:   1,
+		},
+		{
+			name:       "Login command with provider bad provider value",
+			args:       []string{"opkssh", "login", "-provider=badvalue"},
+			wantOutput: "ERROR Invalid provider argument format. Expected format <issuer>,<client_id> or <issuer>,<client_id>,<client_secret>",
+			wantExit:   1,
+		},
+		{
+			name:       "Login command with provider bad provider issuer value",
+			args:       []string{"opkssh", "login", "-provider=badissuer.com,client_id"},
+			wantOutput: "ERROR Invalid provider issuer value. Expected issuer to start with 'https://' got (badissuer.com)",
+			wantExit:   1,
+		},
+		{
+			name:       "Login command with provider bad provider issuer value",
+			args:       []string{"opkssh", "login", "-provider=https://badissuer.com,client_id"},
+			wantOutput: "ERROR Unknown issuer supplied: https://badissuer.com",
+			wantExit:   1,
+		},
+
+		{
+			name:       "Login command with provider bad provider good azure issuer but no client id value",
+			args:       []string{"opkssh", "login", "-provider=https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0,"},
+			wantOutput: "ERROR Invalid provider client-ID value got ()",
+			wantExit:   1,
+		},
+		{
+			name:       "Login command with provider bad provider good google issuer but no client id value",
+			args:       []string{"opkssh", "login", "-provider=https://accounts.google.com,client_id"},
+			wantOutput: "ERROR Invalid provider argument format. Expected format for google: <issuer>,<client_id>,<client_secret>",
+			wantExit:   1,
+		},
+		{
+			name:       "Login command with provider bad provider good google issuer but no client secret value",
+			args:       []string{"opkssh", "login", "-provider=https://accounts.google.com,client_id,"},
+			wantOutput: "ERROR Invalid provider client secret value got ()",
+			wantExit:   1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmdOutput, exitCode := RunCliAndCaptureResult(t, tt.args)
+			require.Contains(t, cmdOutput, tt.wantOutput, "Incorrect command output")
+			require.Equal(t, tt.wantExit, exitCode, "Incorrect Exit code")
+
 		})
 	}
 }


### PR DESCRIPTION
Adds the ability to specify the issuer and client ID you wish to login to via a command-line argument.

Also adds some command parsing smoke tests.


`-provider` allows you to supply the issuer and client-id of the OP, a.k.a. provider, you want to use. This short circuits the web chooser and directly opens the providers auth page. The values sent to the provider are delimited by `,`. For instance the following command:

```
.\opkssh.exe login -provider=https://accounts.google.com,184968138938-g1fddl5tglo7mnlbdak8hbsqhhf79f32.apps.googleusercontent.com,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
```

- issuer = https://accounts.google.com
- client ID = 184968138938-g1fddl5tglo7mnlbdak8hbsqhhf79f32.apps.googleusercontent.com
- client Secret = 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

Note the client secret is only required for Google and despite it's name is not a secret.

Fixes https://github.com/openpubkey/opkssh/issues/16

## Tests

- Tested on windows connecting to ubuntu using Google as the OP.
- Added unittests for command parsing

