### PR TITLE
Add support for generic OpenID Connect providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,31 @@ AuthorizedKeysCommand /usr/local/bin/opkssh verify %u %k %t
 AuthorizedKeysCommandUser opksshuser
 ```
 
+
+## Custom OIDC (Authentik, Authelia, Keycloak, Zitadel...)
+
+### Client:
+
+To log in using a custom OIDC provider, run:
+
+```bash
+opkssh login -provider https://authentik.local/application/o/opkssh/ -client-id SuperClientID
+```
+
+### Server:
+
+In the `/etc/opk/providers` file, add the following line to recognize the custom provider:
+
+```
+https://authentik.local/application/o/opkssh/,SuperClientID 24h
+```
+
+Then, add a user with:
+
+```bash
+opkssh add user user@yourfqdn.tld https://authentik.local/application/o/opkssh/
+```
+
 ## More information
 
 We document how to manually install opkssh on a server [here](scripts/installing.md).

--- a/README.md
+++ b/README.md
@@ -264,6 +264,12 @@ Then, add a user with:
 opkssh add user user@yourfqdn.tld https://authentik.local/application/o/opkssh/
 ```
 
+### Tested :
+| **OIDC**  | **Public (ClientId only)** | **Confidential (ClientId + Secret)** | **Specific notes**                                                 |
+|-----------|----------------------------|--------------------------------------|--------------------------------------------------------------------|
+| Authentik |              ✅             |                   ✅                  | Do not add a certificate in the encryption section of the provider |
+| Zitadel   |              ✅             |                   ✅                  | Check the UserInfo box on the Token Settings                       |
+
 ## More information
 
 We document how to manually install opkssh on a server [here](scripts/installing.md).

--- a/README.md
+++ b/README.md
@@ -265,11 +265,12 @@ opkssh add root alice@example.com https://authentik.local/application/o/opkssh/
 ```
 
 ### Tested :
-| **OIDC**  | **Public (ClientId only)** | **Confidential (ClientId + Secret)** | **Specific notes**                                                 |
-|-----------|----------------------------|--------------------------------------|--------------------------------------------------------------------|
-| Authentik |              ✅             |                   ✅                  | Do not add a certificate in the encryption section of the provider |
-| Zitadel   |              ✅             |                   ✅                  | Check the UserInfo box on the Token Settings                       |
+| **OIDC**  | **Tested** | **Specific notes**                                                 |
+|-----------|------------|--------------------------------------------------------------------|
+| Authentik |      ✅     | Do not add a certificate in the encryption section of the provider |
+| Zitadel   |      ✅     | Check the UserInfo box on the Token Settings                       |
 
+#### Do not use Confidential/Secret mode **only** ClientId is needed
 ## More information
 
 We document how to manually install opkssh on a server [here](scripts/installing.md).

--- a/main.go
+++ b/main.go
@@ -160,8 +160,17 @@ func run() int {
 				opts.GQSign = false
 				provider = providers.NewGitlabOpWithOptions(opts)
 			} else {
-				log.Printf("ERROR Unknown issuer supplied: %v \n", issuerArg)
-				return 1
+				// Generic provider - Need signing, no encryption
+				opts := providers.GetDefaultGoogleOpOptions()
+				opts.Issuer = issuerArg
+				opts.ClientID = clientIDArg
+				opts.GQSign = false
+
+				if len(parts) == 3 {
+					opts.ClientSecret = parts[2]
+				}
+
+				provider = providers.NewGoogleOpWithOptions(opts)
 			}
 		} else if providerFromLdFlags != nil {
 			provider = providerFromLdFlags

--- a/main_test.go
+++ b/main_test.go
@@ -191,12 +191,6 @@ func TestRun(t *testing.T) {
 			wantOutput: "ERROR Invalid provider issuer value. Expected issuer to start with 'https://' got (badissuer.com)",
 			wantExit:   1,
 		},
-		{
-			name:       "Login command with provider bad provider issuer value",
-			args:       []string{"opkssh", "login", "-provider=https://badissuer.com,client_id"},
-			wantOutput: "ERROR Unknown issuer supplied: https://badissuer.com",
-			wantExit:   1,
-		},
 
 		{
 			name:       "Login command with provider bad provider good azure issuer but no client id value",

--- a/policy/providerloader.go
+++ b/policy/providerloader.go
@@ -30,7 +30,6 @@ type ProvidersRow struct {
 	Issuer           string
 	ClientID         string
 	ExpirationPolicy string
-	ClientSecret	 string
 }
 
 func (p ProvidersRow) GetExpirationPolicy() (verifier.ExpirationPolicy, error) {
@@ -94,7 +93,6 @@ func (p *ProviderPolicy) CreateVerifier() (*verifier.Verifier, error) {
 			opts := providers.GetDefaultGoogleOpOptions()
 			opts.Issuer = row.Issuer
 			opts.ClientID = row.ClientID
-			opts.ClientSecret = row.ClientSecret
 			provider = providers.NewGoogleOpWithOptions(opts)
 		}
 
@@ -183,17 +181,10 @@ func (o *ProvidersFileLoader) FromTable(input []byte, path string) *ProviderPoli
 			continue
 		}
 
-		secret := ""
-		// Secret is optional
-		if len(row) == 3 {
-			secret = row[3]
-		}
-
 		policyRow := ProvidersRow{
 			Issuer:           row[0],
 			ClientID:         row[1],
 			ExpirationPolicy: row[2], //TODO: Validate this so that we can determine the line number that has the error
-			ClientSecret:     secret,
 		}
 		policy.AddRow(policyRow)
 	}

--- a/policy/providerloader_test.go
+++ b/policy/providerloader_test.go
@@ -107,19 +107,6 @@ func TestProviderPolicy_CreateVerifier_Gitlab(t *testing.T) {
 	require.NotNil(t, ver)
 }
 
-// Test ProviderPolicy.CreateVerifier with an unsupported issuer.
-func TestProviderPolicy_CreateVerifier_UnsupportedIssuer(t *testing.T) {
-	policy := &ProviderPolicy{}
-	policy.AddRow(ProvidersRow{
-		Issuer:           "https://unsupported.com",
-		ClientID:         "test-unsupported",
-		ExpirationPolicy: "24h",
-	})
-	ver, err := policy.CreateVerifier()
-	require.ErrorContains(t, err, "unsupported issuer")
-	require.Nil(t, ver)
-}
-
 // Test ProviderPolicy.CreateVerifier with an invalid expiration policy.
 func TestProviderPolicy_CreateVerifier_InvalidExpiration(t *testing.T) {
 	policy := &ProviderPolicy{}


### PR DESCRIPTION
This PR introduces support for generic OpenID Connect (OIDC) providers in `opkssh`, enabling authentication via any OIDC-compliant identity provider. Previously, `opkssh` supported only specific providers like Google, Microsoft/Azure, and GitLab. With this enhancement, users can configure any OIDC provider by specifying the provider's URL and client ID.

**Changes:**
- Modified the authentication flow to accept dynamic OIDC provider configurations.
- Updated the `opkssh login` command to allow specifying a custom OIDC provider and client ID.

**Usage:**

*Client:*
To log in using a custom OIDC provider, run:

```bash
opkssh login -provider https://authentik.local/application/o/opkssh/ -client-id SuperClientID
```

*Server:*
In the `/etc/opk/providers` file, add the following line to recognize the custom provider:

```
https://authentik.local/application/o/opkssh/,SuperClientID 24h
```

Then, add a user with:

```bash
opkssh add user user@yourfqdn.tld https://authentik.local/application/o/opkssh/
```


**Testing:**
Tested with [[Authentik](https://goauthentik.io/)](https://goauthentik.io/) as a generic OIDC provider. Successfully authenticated and established SSH connections using `opkssh` with the custom provider configuration.

**Documentation:**
Updated the README to include instructions for configuring and using generic OIDC providers with `opkssh`.

**Motivation:**
Enabling support for generic OIDC providers allows organizations to integrate `opkssh` with their existing identity providers, enhancing flexibility and security in SSH access management.

By submitting this PR, I aim to make `opkssh` more versatile and adaptable to various authentication infrastructures.