### PR TITLE
tests: Removes dir creation from docker script to ensure add creates them in tests

### DIFF
--- a/test/integration/add_test.go
+++ b/test/integration/add_test.go
@@ -161,31 +161,31 @@ func TestAdd(t *testing.T) {
 
 			// Determine expected values based on sub-test options
 			var expectedPolicyFilepath, expectedUser, expectedGroup, expectedPerms string
-			var userPolicyFile bool
+			var isUserPolicyFile bool
 			if tt.useSudo {
 				expectedPolicyFilepath = policy.SystemDefaultPolicyPath
 				expectedUser = RootUser
 				expectedGroup = UserGroup
 				expectedPerms = "640"
-				userPolicyFile = false
+				isUserPolicyFile = false
 			} else {
 				expectedPolicyFilepath = path.Join("/home/", tt.cmdUser, ".opk", "auth_id")
 				expectedUser = tt.cmdUser
 				expectedGroup = tt.cmdUser
 				expectedPerms = "600"
-				userPolicyFile = true
+				isUserPolicyFile = true
 			}
 
 			// Install automatically creates the system auth_id file, so can assume it exists
-			if userPolicyFile {
+			if isUserPolicyFile {
 				policyFileExists := FileExists(t, container.Container, expectedPolicyFilepath)
 				require.False(t, policyFileExists, "home policy file should not exist yet in a fresh test container")
 
 				// If test needs a preexisting auth_id file, create it
 				if tt.preexistingHomeAuthIdFile {
-					CreateAuthIdFile(t, container.Container, expectedPolicyFilepath, tt.cmdUser, userPolicyFile)
+					CreateAuthIdFile(t, container.Container, expectedPolicyFilepath, tt.cmdUser, isUserPolicyFile)
 					policyFileExists := FileExists(t, container.Container, expectedPolicyFilepath)
-					require.True(t, policyFileExists, "policy file should have been created in test container")
+					require.True(t, policyFileExists, "policy file should have been created in test container (test is broken)")
 				}
 			}
 
@@ -201,7 +201,7 @@ func TestAdd(t *testing.T) {
 
 			if tt.shouldCmdFail {
 				assert.Equal(t, 1, code, "add command should fail")
-				if tt.preexistingHomeAuthIdFile && userPolicyFile {
+				if tt.preexistingHomeAuthIdFile && isUserPolicyFile {
 					code, policyContents := executeCommandAsUser(t, container.Container, []string{"cat", expectedPolicyFilepath}, RootUser)
 					require.Equal(t, 0, code, "failed to read policy file")
 					assert.Empty(t, policyContents, "policy file should not be updated")

--- a/test/integration/add_test.go
+++ b/test/integration/add_test.go
@@ -71,7 +71,8 @@ func CreateAuthIdFile(t *testing.T, container testcontainers.Container, filePath
 		// Set the permissions for the user policy file to 600
 		code, _ = executeCommandAsUser(t, container, []string{"chmod", "600", filePath}, RootUser)
 		require.Equal(t, 0, code, "failed to set permissions for user policy file")
-		code, _ = executeCommandAsUser(t, container, []string{"chown", cmdUser, filePath}, RootUser)
+		userAndGroup := fmt.Sprintf("%s:%s", cmdUser, cmdUser)
+		code, _ = executeCommandAsUser(t, container, []string{"chown", userAndGroup, filePath}, RootUser)
 		require.Equal(t, 0, code, "failed to set ownership for user policy file")
 	} else {
 		// Set the permissions for the system policy file to 640

--- a/test/integration/add_test.go
+++ b/test/integration/add_test.go
@@ -53,49 +53,92 @@ func executeCommandAsUser(t *testing.T, container testcontainers.Container, cmd 
 	return code, string(b)
 }
 
+func FileExists(t *testing.T, container testcontainers.Container, filePath string) bool {
+	code, _ := executeCommandAsUser(t, container, []string{"test", "-f", filePath}, RootUser)
+	if code != 0 {
+		return false
+	}
+	return true
+}
+
+func CreateAuthIdFile(t *testing.T, container testcontainers.Container, filePath string, cmdUser string, userPolicyFile bool) {
+	// Create the auth_id file if it doesn't exist
+	code, _ := executeCommandAsUser(t, container, []string{"mkdir", "-p", path.Dir(filePath)}, RootUser)
+	require.Equal(t, 0, code, "failed to create user auth_id directory")
+	code, _ = executeCommandAsUser(t, container, []string{"touch", filePath}, RootUser)
+	require.Equal(t, 0, code, "failed to create user auth_id file")
+	if userPolicyFile {
+		// Set the permissions for the user policy file to 600
+		code, _ = executeCommandAsUser(t, container, []string{"chmod", "600", filePath}, RootUser)
+		require.Equal(t, 0, code, "failed to set permissions for user policy file")
+		code, _ = executeCommandAsUser(t, container, []string{"chown", cmdUser, filePath}, RootUser)
+		require.Equal(t, 0, code, "failed to set ownership for user policy file")
+	} else {
+		// Set the permissions for the system policy file to 640
+		code, _ = executeCommandAsUser(t, container, []string{"chmod", "640", filePath}, RootUser)
+		require.Equal(t, 0, code, "failed to set permissions for system policy file")
+		code, _ = executeCommandAsUser(t, container, []string{"chown", "root:opksshuser", filePath}, RootUser)
+		require.Equal(t, 0, code, "failed to set ownership for system policy file")
+	}
+}
+
 func TestAdd(t *testing.T) {
 	// Test adding an allowed principal to an opkssh policy
 	issuer := fmt.Sprintf("http://oidc.local:%s/", issuerPort)
 
 	tests := []struct {
-		name             string
-		binaryPath       string
-		useSudo          bool
-		cmdUser          string
-		desiredPrincipal string
-		shouldCmdFail    bool
+		name                  string
+		binaryPath            string
+		useSudo               bool
+		cmdUser               string
+		desiredPrincipal      string
+		preexistingAuthIdFile bool
+		shouldCmdFail         bool
 	}{
 		{
-			name:             "sudoer user can update root policy",
-			binaryPath:       "/usr/local/bin/opkssh",
-			useSudo:          true,
-			cmdUser:          SudoerUser,
-			desiredPrincipal: SudoerUser,
-			shouldCmdFail:    false,
+			name:                  "sudoer user can update root policy",
+			binaryPath:            "/usr/local/bin/opkssh",
+			useSudo:               true,
+			cmdUser:               SudoerUser,
+			desiredPrincipal:      SudoerUser,
+			preexistingAuthIdFile: true,
+			shouldCmdFail:         false,
 		},
 		{
-			name:             "sudoer user can update root policy with principal != self",
-			binaryPath:       "/usr/local/bin/opkssh",
-			useSudo:          true,
-			cmdUser:          SudoerUser,
-			desiredPrincipal: UnprivUser,
-			shouldCmdFail:    false,
+			name:                  "sudoer user can update root policy with principal != self",
+			binaryPath:            "/usr/local/bin/opkssh",
+			useSudo:               true,
+			cmdUser:               SudoerUser,
+			desiredPrincipal:      UnprivUser,
+			preexistingAuthIdFile: true,
+			shouldCmdFail:         false,
 		},
 		{
-			name:             "unprivileged user can update their user policy",
-			binaryPath:       "/usr/local/bin/opkssh",
-			useSudo:          false,
-			cmdUser:          UnprivUser,
-			desiredPrincipal: UnprivUser,
-			shouldCmdFail:    false,
+			name:                  "unprivileged user creates an auth_id file (no preexisting auth_id file)",
+			binaryPath:            "/usr/local/bin/opkssh",
+			useSudo:               false,
+			cmdUser:               UnprivUser,
+			desiredPrincipal:      UnprivUser,
+			preexistingAuthIdFile: false,
+			shouldCmdFail:         false,
 		},
 		{
-			name:             "unprivileged user cannot add principal != self",
-			binaryPath:       "/usr/local/bin/opkssh",
-			useSudo:          false,
-			cmdUser:          UnprivUser,
-			desiredPrincipal: SudoerUser,
-			shouldCmdFail:    true,
+			name:                  "unprivileged user can update their user policy",
+			binaryPath:            "/usr/local/bin/opkssh",
+			useSudo:               false,
+			cmdUser:               UnprivUser,
+			desiredPrincipal:      UnprivUser,
+			preexistingAuthIdFile: true,
+			shouldCmdFail:         false,
+		},
+		{
+			name:                  "unprivileged user cannot add principal != self",
+			binaryPath:            "/usr/local/bin/opkssh",
+			useSudo:               false,
+			cmdUser:               UnprivUser,
+			desiredPrincipal:      SudoerUser,
+			preexistingAuthIdFile: true,
+			shouldCmdFail:         true,
 		},
 	}
 	for _, tt := range tests {
@@ -127,23 +170,41 @@ func TestAdd(t *testing.T) {
 
 			// Determine expected values based on sub-test options
 			var expectedPolicyFilepath, expectedUser, expectedGroup, expectedPerms string
+			var userPolicyFile bool
 			if tt.useSudo {
 				expectedPolicyFilepath = policy.SystemDefaultPolicyPath
 				expectedUser = RootUser
 				expectedGroup = UserGroup
 				expectedPerms = "640"
+				userPolicyFile = false
 			} else {
 				expectedPolicyFilepath = path.Join("/home/", tt.cmdUser, ".opk", "auth_id")
 				expectedUser = tt.cmdUser
 				expectedGroup = tt.cmdUser
 				expectedPerms = "600"
+				userPolicyFile = true
+			}
+
+			policyFileExists := FileExists(t, container.Container, expectedPolicyFilepath)
+			require.False(t, policyFileExists, "policy file should not exist yet in a fresh test container")
+
+			// If test needs a preexisting auth_id file, create it
+			if tt.preexistingAuthIdFile {
+				CreateAuthIdFile(t, container.Container, expectedPolicyFilepath, tt.cmdUser, userPolicyFile)
+				policyFileExists := FileExists(t, container.Container, expectedPolicyFilepath)
+				require.True(t, policyFileExists, "policy file should have been created in test container")
 			}
 
 			if tt.shouldCmdFail {
 				assert.Equal(t, 1, code, "add command should fail")
-				code, policyContents := executeCommandAsUser(t, container.Container, []string{"cat", expectedPolicyFilepath}, RootUser)
-				require.Equal(t, 0, code, "failed to read policy file")
-				assert.Empty(t, policyContents, "policy file should not be updated")
+				if tt.preexistingAuthIdFile {
+					code, policyContents := executeCommandAsUser(t, container.Container, []string{"cat", expectedPolicyFilepath}, RootUser)
+					require.Equal(t, 0, code, "failed to read policy file")
+					assert.Empty(t, policyContents, "policy file should not be updated")
+				} else {
+					code, _ = executeCommandAsUser(t, container.Container, []string{"test", "-f", expectedPolicyFilepath}, RootUser)
+					assert.NotEqual(t, 0, code, "policy file should not exist")
+				}
 			} else {
 				require.Equal(t, 0, code, "failed to run add command")
 

--- a/test/integration/add_test.go
+++ b/test/integration/add_test.go
@@ -158,16 +158,6 @@ func TestAdd(t *testing.T) {
 				require.NoError(t, container.Terminate(TestCtx), "failed to terminate add_test container")
 			})
 
-			// Build add command based on sub-test options
-			addCmd := fmt.Sprintf("add %s foo@example.com %s", tt.desiredPrincipal, issuer)
-			cmd := []string{tt.binaryPath, addCmd}
-			if tt.useSudo {
-				cmd = append([]string{"sudo"}, cmd...)
-			}
-
-			// Execute add command
-			code, _ := executeCommandAsUser(t, container.Container, []string{"/bin/bash", "-c", strings.Join(cmd, " ")}, tt.cmdUser)
-
 			// Determine expected values based on sub-test options
 			var expectedPolicyFilepath, expectedUser, expectedGroup, expectedPerms string
 			var userPolicyFile bool
@@ -194,6 +184,16 @@ func TestAdd(t *testing.T) {
 				policyFileExists := FileExists(t, container.Container, expectedPolicyFilepath)
 				require.True(t, policyFileExists, "policy file should have been created in test container")
 			}
+
+			// Build add command based on sub-test options
+			addCmd := fmt.Sprintf("add %s foo@example.com %s", tt.desiredPrincipal, issuer)
+			cmd := []string{tt.binaryPath, addCmd}
+			if tt.useSudo {
+				cmd = append([]string{"sudo"}, cmd...)
+			}
+
+			// Execute add command
+			code, _ := executeCommandAsUser(t, container.Container, []string{"/bin/bash", "-c", strings.Join(cmd, " ")}, tt.cmdUser)
 
 			if tt.shouldCmdFail {
 				assert.Equal(t, 1, code, "add command should fail")

--- a/test/integration/ssh_server/centos_opkssh.Dockerfile
+++ b/test/integration/ssh_server/centos_opkssh.Dockerfile
@@ -60,14 +60,6 @@ RUN opkssh --version
 RUN ls -l /usr/local/bin
 RUN printenv PATH
 
-# Setup OPK directories/files (unprivileged "test2" user)
-RUN mkdir -p /home/test2/.opk 
-RUN chown test2:test2 /home/test2/.opk
-RUN chmod 750 /home/test2/.opk
-# Create personal policy file in user's home directory
-RUN touch /home/test2/.opk/auth_id
-RUN chown test2:test2 /home/test2/.opk/auth_id
-RUN chmod 600 /home/test2/.opk/auth_id
 ARG ISSUER_PORT="9998"
 RUN echo "http://oidc.local:${ISSUER_PORT}/ web oidc_refreshed" >> /etc/opk/providers
 

--- a/test/integration/ssh_server/debian_opkssh.Dockerfile
+++ b/test/integration/ssh_server/debian_opkssh.Dockerfile
@@ -46,18 +46,6 @@ RUN chmod +x ./scripts/install-linux.sh
 RUN bash ./scripts/install-linux.sh --install-from=opksshbuild --no-sshd-restart
 # RUN chmod 700 /usr/local/bin/opkssh
 
-# Setup OPK directories/files (unprivileged "test2" user)
-RUN mkdir -p /home/test2/.opk 
-RUN chown test2:test2 /home/test2/.opk
-RUN chmod 750 /home/test2/.opk
-# Create personal policy file in user's home directory
-RUN touch /home/test2/.opk/auth_id
-RUN chown test2:test2 /home/test2/.opk/auth_id
-RUN chmod 600 /home/test2/.opk/auth_id
-
-
-
-
 RUN echo "http://oidc.local:${ISSUER_PORT}/ web oidc_refreshed" >> /etc/opk/providers
 
 # Add integration test user as allowed email in policy (this directly tests


### PR DESCRIPTION
Currently the docker scripts create the auth_id files in the user's home directory. Unfortunately this means our integration tests do not test that the add subcommand creates the directories if they don't exist because they always exist

Fixes https://github.com/openpubkey/opkssh/issues/36