### PR TITLE
Adds sftp to integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,11 @@ Since your PK Token has been saved as an SSH key you can SSH as normal:
 ssh root@example.com
 ```
 
-This works because SSH sends the SSH public key opkssh wrote in `~/.ssh/id_ecdsas` to the server and sshd running on the server will send the public key to the opkssh command to verify.
+This works because SSH sends the SSH public key opkssh wrote in `~/.ssh/id_ecdsas` to the server and sshd running on the server will send the public key to the opkssh command to verify. This also works for other protocols that build on ssh like [sftp](https://en.wikipedia.org/wiki/SSH_File_Transfer_Protocol) or ssh tunnels.
+
+```bash
+sftp e0@192.168.1.170
+```
 
 ### Installing on a Server
 

--- a/commands/login.go
+++ b/commands/login.go
@@ -389,7 +389,7 @@ func writeKeys(seckeyPath string, pubkeyPath string, seckeySshPem []byte, certBy
 		return err
 	}
 
-	fmt.Printf("Writing opk ssh public key to %s and corresponding secret key to %s", pubkeyPath, seckeyPath)
+	fmt.Printf("Writing opk ssh public key to %s and corresponding secret key to %s\n", pubkeyPath, seckeyPath)
 
 	certBytes = append(certBytes, []byte(" openpubkey")...)
 	// Write ssh public key (certificate) to filesystem

--- a/test/integration/integration.go
+++ b/test/integration/integration.go
@@ -133,6 +133,9 @@ func GetOPKSshKey() (ssh.PublicKey, string, error) {
 			continue
 		}
 
+		certCopy := parsedPubKey.(*ssh.Certificate)
+		fmt.Println("SFTP certCopy.ValidPrincipals ", certCopy.ValidPrincipals)
+
 		// Check if it's an OPK ssh key
 		if comment == "openpubkey" {
 			pubKey = parsedPubKey

--- a/test/integration/integration.go
+++ b/test/integration/integration.go
@@ -133,9 +133,6 @@ func GetOPKSshKey() (ssh.PublicKey, string, error) {
 			continue
 		}
 
-		certCopy := parsedPubKey.(*ssh.Certificate)
-		fmt.Println("SFTP certCopy.ValidPrincipals ", certCopy.ValidPrincipals)
-
 		// Check if it's an OPK ssh key
 		if comment == "openpubkey" {
 			pubKey = parsedPubKey

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -373,39 +373,17 @@ func TestEndToEndSSH(t *testing.T) {
 	remoteTestFilePath := "/home/test/testfile.txt"
 	localTestFilePath := "testfile.txt"
 
-	testContent := "IF YOU CAN READ THIS SFTP WORKS!"
-	out, err = exec.Command("bash", "-c", fmt.Sprintf("echo %q > %s", testContent, localTestFilePath)).CombinedOutput()
-	t.Logf("SFTP created local file: %s", string(out))
-	require.NoError(t, err, "failed to create test file")
-
 	_, err = opkSshClient.Run("test -f " + remoteTestFilePath)
 	require.Error(t, err, "expected test file to not exist")
-	// pubKeyFilePath := secKeyFilePath + ".pub"
-	// out, err = exec.Command("cat", pubKeyFilePath).CombinedOutput()
-	// t.Logf("SFTP public key output: %s", string(out))
-	// out, err = exec.Command("cat", secKeyFilePath).CombinedOutput()
-	// t.Logf("SFTP sec key output: %s", string(out))
 
-	// certFilePath := secKeyFilePath + "-cert.pub"
-	// out, err = exec.Command("cp", pubKeyFilePath, certFilePath).CombinedOutput()
-	// t.Logf("SFTP public key copy: %s", string(out))
-	// out, err = exec.Command("cat", certFilePath).CombinedOutput()
-	// t.Logf("SFTP cert key output: %s", string(out))
-
-	// // Test ssh
-	// sshCommand := fmt.Sprintf("ssh -vvv -o StrictHostKeyChecking=no -p %d -i %s %s@%s",
-	// 	uint(serverContainer.Port), secKeyFilePath, serverContainer.User, serverContainer.Host)
-	// t.Logf("SSH command: %s", string(sshCommand))
-	// out, err = exec.Command("bash", "-c", sshCommand).CombinedOutput()
-	// t.Logf("SSH command output: %s", string(out))
-	// require.NoError(t, err, "failed to execute SSH command")
+	testContent := "IF YOU CAN READ THIS SFTP WORKS!"
+	_, err = exec.Command("bash", "-c", fmt.Sprintf("echo %q > %s", testContent, localTestFilePath)).CombinedOutput()
+	require.NoError(t, err, "failed to create test file")
 
 	// Execute the SFTP command to copy the test file to the server
-	sftpCommand := fmt.Sprintf("echo 'put %s %s' | sftp -o StrictHostKeyChecking=no -P %d -i %s %s@%s",
-		localTestFilePath, remoteTestFilePath, uint(serverContainer.Port), secKeyFilePath, serverContainer.User, serverContainer.Host)
-	t.Logf("SFTP command: %s", string(sftpCommand))
+	sftpCommand := fmt.Sprintf("echo 'put %s %s' | sftp -o StrictHostKeyChecking=no -P %d %s@%s",
+		localTestFilePath, remoteTestFilePath, uint(serverContainer.Port), serverContainer.User, serverContainer.Host)
 	out, err = exec.Command("bash", "-c", sftpCommand).CombinedOutput()
-	t.Logf("SFTP command output: %s", string(out))
 	require.NoError(t, err, "failed to execute SFTP command")
 
 	out, err = opkSshClient.Run("cat " + remoteTestFilePath)

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -377,9 +377,8 @@ func TestEndToEndSSH(t *testing.T) {
 	// Execute the SFTP command to copy the test file to the server
 	testContent := "IF YOU CAN READ THIS SFTP WORKS!"
 	pubKeyFilePath := strings.TrimSuffix(secKeyFilePath, ".pub")
-	sftpCommand := fmt.Sprintf("echo '%s' | sftp -o StrictHostKeyChecking=no CertificateFile=%s -i %s %s@%s:%s",
-		testContent, pubKeyFilePath, secKeyFilePath, serverContainer.User, serverContainer.Host, remoteTestFilePath)
-
+	sftpCommand := fmt.Sprintf("echo '%s' | sftp -o StrictHostKeyChecking=no -i %s %s@%s:%s",
+		testContent, pubKeyFilePath, serverContainer.User, serverContainer.Host, remoteTestFilePath)
 	out, err = exec.Command("bash", "-c", sftpCommand).CombinedOutput()
 	t.Logf("SFTP command output: %s", string(out))
 	require.NoError(t, err, "failed to execute SFTP command")

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -393,7 +393,7 @@ func TestEndToEndSSH(t *testing.T) {
 	t.Logf("SFTP cert key output: %s", string(out))
 
 	// Test ssh
-	sshCommand := fmt.Sprintf("ssh -vvv -o StrictHostKeyChecking=no -P %d -i %s %s@%s",
+	sshCommand := fmt.Sprintf("ssh -vvv -o StrictHostKeyChecking=no -p %d -i %s %s@%s",
 		uint(serverContainer.Port), secKeyFilePath, serverContainer.User, serverContainer.Host)
 	t.Logf("SSH command: %s", string(sshCommand))
 	out, err = exec.Command("bash", "-c", sshCommand).CombinedOutput()

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -28,6 +28,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"testing"
@@ -377,7 +378,7 @@ func TestEndToEndSSH(t *testing.T) {
 	testContent := "IF YOU CAN READ THIS SFTP WORKS!"
 	sftpCommand := fmt.Sprintf("echo '%s' | sftp -o StrictHostKeyChecking=no -i %s %s@%s:%s",
 		testContent, secKeyFilePath, serverContainer.User, serverContainer.Host, remoteTestFilePath)
-	out, err = opkSshClient.Run(sftpCommand)
+	out, err = exec.Command("bash", "-c", sftpCommand).CombinedOutput()
 	t.Logf("SFTP command output: %s", string(out))
 	require.NoError(t, err, "failed to execute SFTP command")
 

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -386,6 +386,20 @@ func TestEndToEndSSH(t *testing.T) {
 	out, err = exec.Command("cat", secKeyFilePath).CombinedOutput()
 	t.Logf("SFTP sec key output: %s", string(out))
 
+	certFilePath := secKeyFilePath + "-cert.pub"
+	out, err = exec.Command("cp", pubKeyFilePath, certFilePath).CombinedOutput()
+	t.Logf("SFTP public key copy: %s", string(out))
+	out, err = exec.Command("cat", certFilePath).CombinedOutput()
+	t.Logf("SFTP cert key output: %s", string(out))
+
+	// Test ssh
+	sshCommand := fmt.Sprintf("ssh -vvv -o StrictHostKeyChecking=no -i %s %s@%s",
+		secKeyFilePath, serverContainer.User, serverContainer.Host)
+	t.Logf("SSH command: %s", string(sshCommand))
+	out, err = exec.Command("bash", "-c", sshCommand).CombinedOutput()
+	t.Logf("SSH command output: %s", string(out))
+	require.NoError(t, err, "failed to execute SSH command")
+
 	// Execute the SFTP command to copy the test file to the server
 	sftpCommand := fmt.Sprintf("echo 'put %s' | sftp -vvv -o StrictHostKeyChecking=no -i %s %s@%s:%s",
 		localTestFilePath, secKeyFilePath, serverContainer.User, serverContainer.Host, remoteTestFilePath)

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -376,8 +376,8 @@ func TestEndToEndSSH(t *testing.T) {
 
 	// Execute the SFTP command to copy the test file to the server
 	testContent := "IF YOU CAN READ THIS SFTP WORKS!"
-	sftpCommand := fmt.Sprintf("echo '%s' | sftp -o StrictHostKeyChecking=no -i %s %s@%s:%s",
-		testContent, secKeyFilePath, serverContainer.User, serverContainer.Host, remoteTestFilePath)
+	sftpCommand := fmt.Sprintf("echo '%s' | sftp -o StrictHostKeyChecking=no %s@%s:%s",
+		testContent, serverContainer.User, serverContainer.Host, remoteTestFilePath)
 	out, err = exec.Command("bash", "-c", sftpCommand).CombinedOutput()
 	t.Logf("SFTP command output: %s", string(out))
 	require.NoError(t, err, "failed to execute SFTP command")

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -370,7 +370,7 @@ func TestEndToEndSSH(t *testing.T) {
 
 	t.Log("Testing SFTP")
 	// Ensure the test file does not exist
-	remoteTestFilePath := "/tmp/testfile.txt"
+	remoteTestFilePath := "/home/test/testfile.txt"
 	_, err = opkSshClient.Run("test -f " + remoteTestFilePath)
 	require.Error(t, err, "expected test file to not exist")
 

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -376,8 +376,10 @@ func TestEndToEndSSH(t *testing.T) {
 
 	// Execute the SFTP command to copy the test file to the server
 	testContent := "IF YOU CAN READ THIS SFTP WORKS!"
-	sftpCommand := fmt.Sprintf("echo '%s' | sftp -o StrictHostKeyChecking=no %s@%s:%s",
-		testContent, serverContainer.User, serverContainer.Host, remoteTestFilePath)
+	pubKeyFilePath := strings.TrimSuffix(secKeyFilePath, ".pub")
+	sftpCommand := fmt.Sprintf("echo '%s' | sftp -o StrictHostKeyChecking=no CertificateFile=%s -i %s %s@%s:%s",
+		testContent, pubKeyFilePath, secKeyFilePath, serverContainer.User, serverContainer.Host, remoteTestFilePath)
+
 	out, err = exec.Command("bash", "-c", sftpCommand).CombinedOutput()
 	t.Logf("SFTP command output: %s", string(out))
 	require.NoError(t, err, "failed to execute SFTP command")

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -369,7 +369,7 @@ func TestEndToEndSSH(t *testing.T) {
 	require.Equal(t, serverContainer.User, strings.TrimSpace(string(out)))
 
 	t.Log("Testing SFTP")
-	// More the testFile doesn't exist
+	// Ensure the test file does not exist
 	remoteTestFilePath := "/tmp/testfile.txt"
 	_, err = opkSshClient.Run("test -f " + remoteTestFilePath)
 	require.Error(t, err, "expected test file to not exist")

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -376,7 +376,7 @@ func TestEndToEndSSH(t *testing.T) {
 
 	// Execute the SFTP command to copy the test file to the server
 	testContent := "IF YOU CAN READ THIS SFTP WORKS!"
-	pubKeyFilePath := strings.TrimSuffix(secKeyFilePath, ".pub")
+	pubKeyFilePath := secKeyFilePath + ".pub"
 	sftpCommand := fmt.Sprintf("echo '%s' | sftp -o StrictHostKeyChecking=no -i %s %s@%s:%s",
 		testContent, pubKeyFilePath, serverContainer.User, serverContainer.Host, remoteTestFilePath)
 	out, err = exec.Command("bash", "-c", sftpCommand).CombinedOutput()

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -393,16 +393,16 @@ func TestEndToEndSSH(t *testing.T) {
 	t.Logf("SFTP cert key output: %s", string(out))
 
 	// Test ssh
-	sshCommand := fmt.Sprintf("ssh -vvv -o StrictHostKeyChecking=no -i %s %s@%s",
-		secKeyFilePath, serverContainer.User, serverContainer.Host)
+	sshCommand := fmt.Sprintf("ssh -vvv -o StrictHostKeyChecking=no -P %d -i %s %s@%s",
+		uint(serverContainer.Port), secKeyFilePath, serverContainer.User, serverContainer.Host)
 	t.Logf("SSH command: %s", string(sshCommand))
 	out, err = exec.Command("bash", "-c", sshCommand).CombinedOutput()
 	t.Logf("SSH command output: %s", string(out))
 	require.NoError(t, err, "failed to execute SSH command")
 
 	// Execute the SFTP command to copy the test file to the server
-	sftpCommand := fmt.Sprintf("echo 'put %s' | sftp -vvv -o StrictHostKeyChecking=no -i %s %s@%s:%s",
-		localTestFilePath, secKeyFilePath, serverContainer.User, serverContainer.Host, remoteTestFilePath)
+	sftpCommand := fmt.Sprintf("echo 'put %s' | sftp -vvv -o StrictHostKeyChecking=no -P %d -i %s %s@%s:%s",
+		localTestFilePath, uint(serverContainer.Port), secKeyFilePath, serverContainer.User, serverContainer.Host, remoteTestFilePath)
 	t.Logf("SFTP command: %s", string(sftpCommand))
 	out, err = exec.Command("bash", "-c", sftpCommand).CombinedOutput()
 	t.Logf("SFTP command output: %s", string(out))

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -377,8 +377,13 @@ func TestEndToEndSSH(t *testing.T) {
 	// Execute the SFTP command to copy the test file to the server
 	testContent := "IF YOU CAN READ THIS SFTP WORKS!"
 	pubKeyFilePath := secKeyFilePath + ".pub"
+	out, err = exec.Command("cat", pubKeyFilePath).CombinedOutput()
+	t.Logf("SFTP public key output: %s", string(out))
+	out, err = exec.Command("cat", secKeyFilePath).CombinedOutput()
+	t.Logf("SFTP sec key output: %s", string(out))
 	sftpCommand := fmt.Sprintf("echo '%s' | sftp -o StrictHostKeyChecking=no -i %s %s@%s:%s",
 		testContent, pubKeyFilePath, serverContainer.User, serverContainer.Host, remoteTestFilePath)
+	t.Logf("SFTP command: %s", string(sftpCommand))
 	out, err = exec.Command("bash", "-c", sftpCommand).CombinedOutput()
 	t.Logf("SFTP command output: %s", string(out))
 	require.NoError(t, err, "failed to execute SFTP command")

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -380,29 +380,29 @@ func TestEndToEndSSH(t *testing.T) {
 
 	_, err = opkSshClient.Run("test -f " + remoteTestFilePath)
 	require.Error(t, err, "expected test file to not exist")
-	pubKeyFilePath := secKeyFilePath + ".pub"
-	out, err = exec.Command("cat", pubKeyFilePath).CombinedOutput()
-	t.Logf("SFTP public key output: %s", string(out))
-	out, err = exec.Command("cat", secKeyFilePath).CombinedOutput()
-	t.Logf("SFTP sec key output: %s", string(out))
+	// pubKeyFilePath := secKeyFilePath + ".pub"
+	// out, err = exec.Command("cat", pubKeyFilePath).CombinedOutput()
+	// t.Logf("SFTP public key output: %s", string(out))
+	// out, err = exec.Command("cat", secKeyFilePath).CombinedOutput()
+	// t.Logf("SFTP sec key output: %s", string(out))
 
-	certFilePath := secKeyFilePath + "-cert.pub"
-	out, err = exec.Command("cp", pubKeyFilePath, certFilePath).CombinedOutput()
-	t.Logf("SFTP public key copy: %s", string(out))
-	out, err = exec.Command("cat", certFilePath).CombinedOutput()
-	t.Logf("SFTP cert key output: %s", string(out))
+	// certFilePath := secKeyFilePath + "-cert.pub"
+	// out, err = exec.Command("cp", pubKeyFilePath, certFilePath).CombinedOutput()
+	// t.Logf("SFTP public key copy: %s", string(out))
+	// out, err = exec.Command("cat", certFilePath).CombinedOutput()
+	// t.Logf("SFTP cert key output: %s", string(out))
 
-	// Test ssh
-	sshCommand := fmt.Sprintf("ssh -vvv -o StrictHostKeyChecking=no -p %d -i %s %s@%s",
-		uint(serverContainer.Port), secKeyFilePath, serverContainer.User, serverContainer.Host)
-	t.Logf("SSH command: %s", string(sshCommand))
-	out, err = exec.Command("bash", "-c", sshCommand).CombinedOutput()
-	t.Logf("SSH command output: %s", string(out))
-	require.NoError(t, err, "failed to execute SSH command")
+	// // Test ssh
+	// sshCommand := fmt.Sprintf("ssh -vvv -o StrictHostKeyChecking=no -p %d -i %s %s@%s",
+	// 	uint(serverContainer.Port), secKeyFilePath, serverContainer.User, serverContainer.Host)
+	// t.Logf("SSH command: %s", string(sshCommand))
+	// out, err = exec.Command("bash", "-c", sshCommand).CombinedOutput()
+	// t.Logf("SSH command output: %s", string(out))
+	// require.NoError(t, err, "failed to execute SSH command")
 
 	// Execute the SFTP command to copy the test file to the server
-	sftpCommand := fmt.Sprintf("echo 'put %s' | sftp -vvv -o StrictHostKeyChecking=no -P %d -i %s %s@%s:%s",
-		localTestFilePath, uint(serverContainer.Port), secKeyFilePath, serverContainer.User, serverContainer.Host, remoteTestFilePath)
+	sftpCommand := fmt.Sprintf("echo 'put %s %s' | sftp -o StrictHostKeyChecking=no -P %d -i %s %s@%s",
+		localTestFilePath, remoteTestFilePath, uint(serverContainer.Port), secKeyFilePath, serverContainer.User, serverContainer.Host)
 	t.Logf("SFTP command: %s", string(sftpCommand))
 	out, err = exec.Command("bash", "-c", sftpCommand).CombinedOutput()
 	t.Logf("SFTP command output: %s", string(out))


### PR DESCRIPTION
- Fixes https://github.com/openpubkey/opkssh/issues/40
- Fixes formatting typo in console output


Tested manually (windows to ubuntu) and sftp works perfectly 

`echo "put file.exe /tmp/file.exe" | sftp root@microsoft.com`