### PR TITLE
bug: Adds login --disable-browser-open flag

### DIFF
--- a/commands/login.go
+++ b/commands/login.go
@@ -46,7 +46,7 @@ import (
 type LoginCmd struct {
 	autoRefresh           bool
 	logDir                string
-	disableOpenBrowserArg bool
+	disableBrowserOpenArg bool
 	providerArg           string
 	providerFromLdFlags   providers.OpenIdProvider
 	pkt                   *pktoken.PKToken
@@ -56,11 +56,11 @@ type LoginCmd struct {
 	principals            []string
 }
 
-func NewLogin(autoRefresh bool, logDir string, disableOpenBrowserArg bool, providerArg string, providerFromLdFlags providers.OpenIdProvider) *LoginCmd {
+func NewLogin(autoRefresh bool, logDir string, disableBrowserOpenArg bool, providerArg string, providerFromLdFlags providers.OpenIdProvider) *LoginCmd {
 	return &LoginCmd{
 		autoRefresh:           autoRefresh,
 		logDir:                logDir,
-		disableOpenBrowserArg: disableOpenBrowserArg,
+		disableBrowserOpenArg: disableBrowserOpenArg,
 		providerArg:           providerArg,
 		providerFromLdFlags:   providerFromLdFlags,
 	}
@@ -80,6 +80,8 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 	} else {
 		log.SetOutput(os.Stdout)
 	}
+
+	openBrowser := !l.disableBrowserOpenArg
 
 	// If the user has supplied commandline arguments for the provider, use those instead of the web chooser
 	var provider providers.OpenIdProvider
@@ -115,21 +117,21 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 			opts.ClientID = clientIDArg
 			opts.ClientSecret = clientSecretArg
 			opts.GQSign = false
-			opts.OpenBrowser = !l.disableOpenBrowserArg
+			opts.OpenBrowser = openBrowser
 			provider = providers.NewGoogleOpWithOptions(opts)
 		} else if strings.HasPrefix(issuerArg, "https://login.microsoftonline.com") {
 			opts := providers.GetDefaultAzureOpOptions()
 			opts.Issuer = issuerArg
 			opts.ClientID = clientIDArg
 			opts.GQSign = false
-			opts.OpenBrowser = l.disableOpenBrowserArg
+			opts.OpenBrowser = openBrowser
 			provider = providers.NewAzureOpWithOptions(opts)
 		} else if strings.HasPrefix(issuerArg, "https://gitlab.com") {
 			opts := providers.GetDefaultGitlabOpOptions()
 			opts.Issuer = issuerArg
 			opts.ClientID = clientIDArg
 			opts.GQSign = false
-			opts.OpenBrowser = !l.disableOpenBrowserArg
+			opts.OpenBrowser = openBrowser
 			provider = providers.NewGitlabOpWithOptions(opts)
 		} else {
 			// Generic provider - Need signing, no encryption
@@ -138,7 +140,7 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 			opts.ClientID = clientIDArg
 			opts.ClientSecret = "" // No client secret for generic providers unless specified
 			opts.GQSign = false
-			opts.OpenBrowser = !l.disableOpenBrowserArg
+			opts.OpenBrowser = openBrowser
 
 			if len(parts) == 3 {
 				opts.ClientSecret = parts[2]
@@ -150,24 +152,24 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 		provider = l.providerFromLdFlags
 	} else {
 		googleOpOptions := providers.GetDefaultGoogleOpOptions()
-		googleOpOptions.OpenBrowser = !l.disableOpenBrowserArg
+		googleOpOptions.OpenBrowser = openBrowser
 		googleOpOptions.GQSign = false
 		googleOp := providers.NewGoogleOpWithOptions(googleOpOptions)
 
 		azureOpOptions := providers.GetDefaultAzureOpOptions()
-		azureOpOptions.OpenBrowser = !l.disableOpenBrowserArg
+		azureOpOptions.OpenBrowser = openBrowser
 		azureOpOptions.GQSign = false
 		azureOp := providers.NewAzureOpWithOptions(azureOpOptions)
 
 		gitlabOpOptions := providers.GetDefaultGitlabOpOptions()
-		gitlabOpOptions.OpenBrowser = !l.disableOpenBrowserArg
+		gitlabOpOptions.OpenBrowser = openBrowser
 		gitlabOpOptions.GQSign = false
 		gitlabOp := providers.NewGitlabOpWithOptions(gitlabOpOptions)
 
 		var err error
 		provider, err = choosers.NewWebChooser(
 			[]providers.BrowserOpenIdProvider{googleOp, azureOp, gitlabOp},
-			!l.disableOpenBrowserArg,
+			!l.disableBrowserOpenArg,
 		).ChooseOp(ctx)
 		if err != nil {
 			return fmt.Errorf("error selecting OpenID provider: %w", err)

--- a/commands/login.go
+++ b/commands/login.go
@@ -167,6 +167,7 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 		var err error
 		provider, err = choosers.NewWebChooser(
 			[]providers.BrowserOpenIdProvider{googleOp, azureOp, gitlabOp},
+			!l.disableOpenBrowserArg,
 		).ChooseOp(ctx)
 		if err != nil {
 			return fmt.Errorf("error selecting OpenID provider: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/jeremija/gosubmit v0.2.7
 	github.com/lestrrat-go/jwx/v2 v2.0.21
 	github.com/melbahja/goph v1.4.0
-	github.com/openpubkey/openpubkey v0.7.3
+	github.com/openpubkey/openpubkey v0.8.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
-github.com/openpubkey/openpubkey v0.7.3 h1:NDc7OLJN2SxEbPjvFmbxZYTstVLPyWxBmPy+TU+/0Z0=
-github.com/openpubkey/openpubkey v0.7.3/go.mod h1:Y/dYOw3jbBJcuWQ0j7J8FSvZbtWiu56CcAK6QIsMJoo=
+github.com/openpubkey/openpubkey v0.8.0 h1:nT3FHHmdqy/JK57plJ69bCCLm0WOKjRDp0WJQvtV4ss=
+github.com/openpubkey/openpubkey v0.8.0/go.mod h1:Y/dYOw3jbBJcuWQ0j7J8FSvZbtWiu56CcAK6QIsMJoo=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.5/go.mod h1:wHDZ0IZX6JcBYRK1TH9bcVq8G7TLpVHYIGJRFnmPfxg=

--- a/main.go
+++ b/main.go
@@ -118,6 +118,7 @@ Arguments:
 	var autoRefresh bool
 	var logDir string
 	var providerArg string
+	var disableOpenBrowserArg bool
 	loginCmd := &cobra.Command{
 		Use:   "login",
 		Short: "Authenticate with an OpenID Provider to generate an SSH key for opkssh",
@@ -151,7 +152,7 @@ Users can then SSH into servers configured to use opkssh as the AuthorizedKeysCo
 				providerFromLdFlags = providers.NewGoogleOpWithOptions(opts)
 			}
 
-			login := commands.NewLogin(autoRefresh, logDir, providerArg, providerFromLdFlags)
+			login := commands.NewLogin(autoRefresh, logDir, disableOpenBrowserArg, providerArg, providerFromLdFlags)
 			if err := login.Run(ctx); err != nil {
 				log.Println("Error executing login command:", err)
 				return err
@@ -163,7 +164,9 @@ Users can then SSH into servers configured to use opkssh as the AuthorizedKeysCo
 	// Define flags for login.
 	loginCmd.Flags().BoolVar(&autoRefresh, "auto-refresh", false, "Automatically refresh PK token after login")
 	loginCmd.Flags().StringVar(&logDir, "log-dir", "", "Directory to write output logs")
+	loginCmd.Flags().BoolVar(&disableOpenBrowserArg, "disable-browser-open", false, "Set this flag to disable opening the browser. Useful for opening the browser manually.")
 	loginCmd.Flags().StringVar(&providerArg, "provider", "", "OpenID Provider specification in the format: <issuer>,<client_id> or <issuer>,<client_id>,<client_secret>")
+
 	rootCmd.AddCommand(loginCmd)
 
 	readhomeCmd := &cobra.Command{

--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ Arguments:
 	var autoRefresh bool
 	var logDir string
 	var providerArg string
-	var disableOpenBrowserArg bool
+	var disableBrowserOpenArg bool
 	loginCmd := &cobra.Command{
 		Use:   "login",
 		Short: "Authenticate with an OpenID Provider to generate an SSH key for opkssh",
@@ -152,7 +152,7 @@ Users can then SSH into servers configured to use opkssh as the AuthorizedKeysCo
 				providerFromLdFlags = providers.NewGoogleOpWithOptions(opts)
 			}
 
-			login := commands.NewLogin(autoRefresh, logDir, disableOpenBrowserArg, providerArg, providerFromLdFlags)
+			login := commands.NewLogin(autoRefresh, logDir, disableBrowserOpenArg, providerArg, providerFromLdFlags)
 			if err := login.Run(ctx); err != nil {
 				log.Println("Error executing login command:", err)
 				return err
@@ -164,9 +164,8 @@ Users can then SSH into servers configured to use opkssh as the AuthorizedKeysCo
 	// Define flags for login.
 	loginCmd.Flags().BoolVar(&autoRefresh, "auto-refresh", false, "Automatically refresh PK token after login")
 	loginCmd.Flags().StringVar(&logDir, "log-dir", "", "Directory to write output logs")
-	loginCmd.Flags().BoolVar(&disableOpenBrowserArg, "disable-browser-open", false, "Set this flag to disable opening the browser. Useful for opening the browser manually.")
+	loginCmd.Flags().BoolVar(&disableBrowserOpenArg, "disable-browser-open", false, "Set this flag to disable opening the browser. Useful for choosing the browser you want to use.")
 	loginCmd.Flags().StringVar(&providerArg, "provider", "", "OpenID Provider specification in the format: <issuer>,<client_id> or <issuer>,<client_id>,<client_secret>")
-
 	rootCmd.AddCommand(loginCmd)
 
 	readhomeCmd := &cobra.Command{


### PR DESCRIPTION
opkssh login automatically opens the user's web browser to authenticate to their OP. This opens the user's default browser but there are cases in which a user wants to use an alternative web browser,  e.g. they use different browsers for different OP accounts for security or privacy.

This PR:
- Adds a flag to turn off opkssh's behavior of automatically opening a browser window `--disable-browser-open`. When this is set no browser is open but opkssh sits and waits for the user to open the browser window.
- Adds a console output message when browser open is disabled that tells the user the URI they should use open in their browser. 

Fixes https://github.com/openpubkey/opkssh/issues/63

On windows this looks like:

When --provider is set:
```powershell
.\opkssh.exe login --disable-browser-open --provider=https://accounts.google.com,206584157355-7cbe4s640tvm7naoludob4ut1emii7sf.apps.googleusercontent.com,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
time="2025-03-31T13:19:44-04:00" level=info msg="listening on http://127.0.0.1:10001/"
time="2025-03-31T13:19:44-04:00" level=info msg="press ctrl+c to stop"
time="2025-03-31T13:19:44-04:00" level=info msg="Open your browser to: http://localhost:10001/login "
```
The user then copy pastes `http://localhost:10001/login` into their browser of choice.

This works for the default flow with the Web Chooser as well:

```powershell
.\opkssh.exe login --disable-browser-open                                                                                    
time="2025-03-31T13:23:17-04:00" level=info msg="Open your browser to: http://localhost:61211/chooser "
```

## TODOs

- [x] Upstream change in OpenPubkey to tell the user the right URL to use
- [X] Manual tests