### PR TITLE
login: support ssh-agent for certificates

### DIFF
--- a/commands/login.go
+++ b/commands/login.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,6 +42,7 @@ import (
 	"github.com/openpubkey/openpubkey/util"
 	"github.com/openpubkey/opkssh/sshcert"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
 )
 
 type LoginCmd struct {
@@ -54,6 +56,20 @@ type LoginCmd struct {
 	alg                   jwa.SignatureAlgorithm
 	client                *client.OpkClient
 	principals            []string
+}
+
+func HasSSHAgent() (string, bool) {
+	return os.LookupEnv("SSH_AUTH_SOCK")
+}
+
+func getExpiration(b []byte) (time.Duration, error) {
+	var claims struct {
+		Expiration int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(b, &claims); err != nil {
+		return 0, fmt.Errorf("malformed refreshed ID token payload: %w", err)
+	}
+	return time.Until(time.Unix(claims.Expiration, 0)) - time.Minute, nil
 }
 
 func NewLogin(autoRefresh bool, logDir string, disableBrowserOpenArg bool, providerArg string, providerFromLdFlags providers.OpenIdProvider) *LoginCmd {
@@ -197,6 +213,17 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 
 func login(ctx context.Context, provider client.OpenIdProvider) (*LoginCmd, error) {
 	var err error
+
+	var sshagent agent.Agent
+	if s, ok := HasSSHAgent(); ok {
+		conn, err := net.Dial("unix", s)
+		if err != nil {
+			return nil, fmt.Errorf("failed to connect to ssh-agent socket: %w", err)
+		}
+		defer conn.Close()
+		sshagent = agent.NewClient(conn)
+	}
+
 	alg := jwa.ES256
 	signer, err := util.GenKeyPair(alg)
 	if err != nil {
@@ -221,16 +248,42 @@ func login(ctx context.Context, provider client.OpenIdProvider) (*LoginCmd, erro
 		return nil, fmt.Errorf("failed to generate SSH cert: %w", err)
 	}
 
-	// Write ssh secret key and public key to filesystem
-	if err := writeKeysToSSHDir(seckeySshPem, certBytes); err != nil {
-		return nil, fmt.Errorf("failed to write SSH keys to filesystem: %w", err)
-	}
-
 	idStr, err := IdentityString(*pkt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse ID Token: %w", err)
 	}
-	fmt.Printf("Keys generated for identity\n%s\n", idStr)
+
+	if _, ok := HasSSHAgent(); ok {
+		pubkey, _, _, _, err := ssh.ParseAuthorizedKey(certBytes)
+		if err != nil {
+			return nil, err
+		}
+		cert, ok := pubkey.(*ssh.Certificate)
+		if !ok {
+			return nil, fmt.Errorf("failed to cast to certificate")
+		}
+
+		lifetime, err := getExpiration(pkt.Payload)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := sshagent.Add(agent.AddedKey{
+			PrivateKey:   signer,
+			Comment:      "openpubkey key",
+			LifetimeSecs: uint32(lifetime.Seconds()),
+			Certificate:  cert,
+		}); err != nil {
+			fmt.Println("failed to ssh-add key to agent: %w", err)
+		}
+		fmt.Printf("Keys generated and added to ssh-agent for identity\n%s\n", idStr)
+	} else {
+		// Write ssh secret key and public key to filesystem
+		if err := writeKeysToSSHDir(seckeySshPem, certBytes); err != nil {
+			return nil, fmt.Errorf("failed to write SSH keys to filesystem: %w", err)
+		}
+		fmt.Printf("Keys generated for identity\n%s\n", idStr)
+	}
 
 	return &LoginCmd{
 		pkt:        pkt,
@@ -257,17 +310,16 @@ func LoginWithRefresh(ctx context.Context, provider providers.RefreshableOpenIdP
 	if loginResult, err := login(ctx, provider); err != nil {
 		return err
 	} else {
-		var claims struct {
-			Expiration int64 `json:"exp"`
-		}
-		if err := json.Unmarshal(loginResult.pkt.Payload, &claims); err != nil {
+		var sshagent agent.Agent
+
+		untilExpired, err := getExpiration(loginResult.pkt.Payload)
+		if err != nil {
 			return err
 		}
 
 		for {
 			// Sleep until a minute before expiration to give us time to refresh
 			// the token and minimize any interruptions
-			untilExpired := time.Until(time.Unix(claims.Expiration, 0)) - time.Minute
 			log.Printf("Waiting for %v before attempting to refresh id_token...", untilExpired)
 			select {
 			case <-time.After(untilExpired):
@@ -282,14 +334,44 @@ func LoginWithRefresh(ctx context.Context, provider providers.RefreshableOpenIdP
 			}
 			loginResult.pkt = refreshedPkt
 
+			if s, ok := HasSSHAgent(); ok {
+				conn, err := net.Dial("unix", s)
+				if err != nil {
+					return fmt.Errorf("failed to connect to ssh-agent socket: %w", err)
+				}
+				defer conn.Close()
+				sshagent = agent.NewClient(conn)
+			}
+
 			certBytes, seckeySshPem, err := createSSHCert(loginResult.pkt, loginResult.signer, loginResult.principals)
 			if err != nil {
 				return fmt.Errorf("failed to generate SSH cert: %w", err)
 			}
 
-			// Write ssh secret key and public key to filesystem
-			if err := writeKeysToSSHDir(seckeySshPem, certBytes); err != nil {
-				return fmt.Errorf("failed to write SSH keys to filesystem: %w", err)
+			if _, ok := HasSSHAgent(); ok {
+				pub, _, _, _, err := ssh.ParseAuthorizedKey(certBytes)
+				if err != nil {
+					return err
+				}
+				cert, ok := pub.(*ssh.Certificate)
+				if !ok {
+					return fmt.Errorf("failed to cast to certificate")
+				}
+
+				if err := sshagent.Add(agent.AddedKey{
+					PrivateKey: loginResult.signer,
+					Comment:    "openpubkey key",
+					// We don't remove the old certificate, we include a lifetime
+					LifetimeSecs: uint32(untilExpired.Seconds()),
+					Certificate:  cert,
+				}); err != nil {
+					fmt.Println("failed to ssh-add key to agent: %w", err)
+				}
+			} else {
+				// Write ssh secret key and public key to filesystem
+				if err := writeKeysToSSHDir(seckeySshPem, certBytes); err != nil {
+					return fmt.Errorf("failed to write SSH keys to filesystem: %w", err)
+				}
 			}
 
 			comPkt, err := refreshedPkt.Compact()
@@ -306,8 +388,9 @@ func LoginWithRefresh(ctx context.Context, provider providers.RefreshableOpenIdP
 				return fmt.Errorf("refreshed ID token payload is not base64 encoded: %w", err)
 			}
 
-			if err = json.Unmarshal(payload, &claims); err != nil {
-				return fmt.Errorf("malformed refreshed ID token payload: %w", err)
+			untilExpired, err = getExpiration(payload)
+			if err != nil {
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
Implement support for opkssh to append created certificates to an available `ssh-agent` instead of writing files into `~/.ssh`.

Certificates are added with a lifetime to the ssh-agent that should correspond to the lifetime of the OIDC token.

Fixes: https://github.com/openpubkey/opkssh/issues/6

Note I haven't added tests yet as it will probably take a bit more time then the feature itself,  should probably look over the general idea for starters.

Note that this does not reuse private keys from an `ssh-agent`, that requires a different approach. See https://github.com/openpubkey/opkssh/issues/72#issuecomment-2765333492