### PR TITLE
feat: Adds flag to print id_token contents on login

### DIFF
--- a/commands/login.go
+++ b/commands/login.go
@@ -47,6 +47,7 @@ type LoginCmd struct {
 	autoRefresh           bool
 	logDir                string
 	disableBrowserOpenArg bool
+	printIdTokenArg       bool
 	providerArg           string
 	providerFromLdFlags   providers.OpenIdProvider
 	pkt                   *pktoken.PKToken
@@ -56,11 +57,12 @@ type LoginCmd struct {
 	principals            []string
 }
 
-func NewLogin(autoRefresh bool, logDir string, disableBrowserOpenArg bool, providerArg string, providerFromLdFlags providers.OpenIdProvider) *LoginCmd {
+func NewLogin(autoRefresh bool, logDir string, disableBrowserOpenArg bool, printIdTokenArg bool, providerArg string, providerFromLdFlags providers.OpenIdProvider) *LoginCmd {
 	return &LoginCmd{
 		autoRefresh:           autoRefresh,
 		logDir:                logDir,
 		disableBrowserOpenArg: disableBrowserOpenArg,
+		printIdTokenArg:       printIdTokenArg,
 		providerArg:           providerArg,
 		providerFromLdFlags:   providerFromLdFlags,
 	}
@@ -179,7 +181,7 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 	// Execute login command
 	if l.autoRefresh {
 		if providerRefreshable, ok := provider.(providers.RefreshableOpenIdProvider); ok {
-			err := LoginWithRefresh(ctx, providerRefreshable)
+			err := LoginWithRefresh(ctx, providerRefreshable, l.printIdTokenArg)
 			if err != nil {
 				return fmt.Errorf("error logging in: %w", err)
 			}
@@ -187,7 +189,7 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 			return fmt.Errorf("supplied OpenID Provider (%v) does not support auto-refresh and auto-refresh argument set to true", provider.Issuer())
 		}
 	} else {
-		err := Login(ctx, provider)
+		err := Login(ctx, provider, l.printIdTokenArg)
 		if err != nil {
 			return fmt.Errorf("error logging in: %w", err)
 		}
@@ -195,7 +197,7 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 	return nil
 }
 
-func login(ctx context.Context, provider client.OpenIdProvider) (*LoginCmd, error) {
+func login(ctx context.Context, provider client.OpenIdProvider, printIdToken bool) (*LoginCmd, error) {
 	var err error
 	alg := jwa.ES256
 	signer, err := util.GenKeyPair(alg)
@@ -226,6 +228,16 @@ func login(ctx context.Context, provider client.OpenIdProvider) (*LoginCmd, erro
 		return nil, fmt.Errorf("failed to write SSH keys to filesystem: %w", err)
 	}
 
+	if printIdToken {
+		idTokenStr, err := PrettyIdToken(*pkt)
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to format ID Token: %w", err)
+		}
+
+		fmt.Printf("id_token:\n%s\n", idTokenStr)
+	}
+
 	idStr, err := IdentityString(*pkt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse ID Token: %w", err)
@@ -243,8 +255,8 @@ func login(ctx context.Context, provider client.OpenIdProvider) (*LoginCmd, erro
 
 // Login performs the OIDC login procedure and creates the SSH certs/keys in the
 // default SSH key location.
-func Login(ctx context.Context, provider client.OpenIdProvider) error {
-	_, err := login(ctx, provider)
+func Login(ctx context.Context, provider client.OpenIdProvider, printIdToken bool) error {
+	_, err := login(ctx, provider, printIdToken)
 	return err
 }
 
@@ -253,8 +265,8 @@ func Login(ctx context.Context, provider client.OpenIdProvider) error {
 // the PKT (and create new SSH certs) indefinitely as its token expires. This
 // function only returns if it encounters an error or if the supplied context is
 // cancelled.
-func LoginWithRefresh(ctx context.Context, provider providers.RefreshableOpenIdProvider) error {
-	if loginResult, err := login(ctx, provider); err != nil {
+func LoginWithRefresh(ctx context.Context, provider providers.RefreshableOpenIdProvider, printIdToken bool) error {
+	if loginResult, err := login(ctx, provider, printIdToken); err != nil {
 		return err
 	} else {
 		var claims struct {
@@ -418,10 +430,27 @@ func IdentityString(pkt pktoken.PKToken) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	claims := idt.GetClaims()
 	if claims.Email == "" {
 		return "Sub, issuer, audience: \n" + claims.Subject + " " + claims.Issuer + " " + claims.Audience, nil
 	} else {
 		return "Email, sub, issuer, audience: \n" + claims.Email + " " + claims.Subject + " " + claims.Issuer + " " + claims.Audience, nil
 	}
+}
+
+func PrettyIdToken(pkt pktoken.PKToken) (string, error) {
+
+	idt, err := oidc.NewJwt(pkt.OpToken)
+	if err != nil {
+		return "", err
+	}
+
+	idt_json, err := json.MarshalIndent(idt.GetClaims(), "", "    ")
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(idt_json[:]), nil
 }

--- a/commands/login.go
+++ b/commands/login.go
@@ -430,7 +430,6 @@ func IdentityString(pkt pktoken.PKToken) (string, error) {
 	if err != nil {
 		return "", err
 	}
-
 	claims := idt.GetClaims()
 	if claims.Email == "" {
 		return "Sub, issuer, audience: \n" + claims.Subject + " " + claims.Issuer + " " + claims.Audience, nil

--- a/main.go
+++ b/main.go
@@ -122,6 +122,7 @@ Arguments:
 	var logDir string
 	var providerArg string
 	var disableBrowserOpenArg bool
+	var printIdTokenArg bool
 	loginCmd := &cobra.Command{
 		SilenceUsage: true,
 		Use:          "login",
@@ -156,7 +157,7 @@ Users can then SSH into servers configured to use opkssh as the AuthorizedKeysCo
 				providerFromLdFlags = providers.NewGoogleOpWithOptions(opts)
 			}
 
-			login := commands.NewLogin(autoRefresh, logDir, disableBrowserOpenArg, providerArg, providerFromLdFlags)
+			login := commands.NewLogin(autoRefresh, logDir, disableBrowserOpenArg, printIdTokenArg, providerArg, providerFromLdFlags)
 			if err := login.Run(ctx); err != nil {
 				log.Println("Error executing login command:", err)
 				return err
@@ -169,6 +170,7 @@ Users can then SSH into servers configured to use opkssh as the AuthorizedKeysCo
 	loginCmd.Flags().BoolVar(&autoRefresh, "auto-refresh", false, "Automatically refresh PK token after login")
 	loginCmd.Flags().StringVar(&logDir, "log-dir", "", "Directory to write output logs")
 	loginCmd.Flags().BoolVar(&disableBrowserOpenArg, "disable-browser-open", false, "Set this flag to disable opening the browser. Useful for choosing the browser you want to use.")
+	loginCmd.Flags().BoolVar(&printIdTokenArg, "print-id-token", false, "Set this flag to print out the contents of the id_token. Useful for inspecting claims.")
 	loginCmd.Flags().StringVar(&providerArg, "provider", "", "OpenID Provider specification in the format: <issuer>,<client_id> or <issuer>,<client_id>,<client_secret>")
 	rootCmd.AddCommand(loginCmd)
 

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -49,7 +49,7 @@ func TestLogin(t *testing.T) {
 	opkProvider, loginURL, err := opServer.OpkProvider()
 	require.NoError(t, err, "failed to create OPK provider")
 	go func() {
-		err := commands.Login(TestCtx, opkProvider)
+		err := commands.Login(TestCtx, opkProvider, false)
 		errCh <- err
 	}()
 

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -319,7 +319,7 @@ func TestEndToEndSSH(t *testing.T) {
 	errCh := make(chan error)
 	t.Log("------- call login cmd ------")
 	go func() {
-		err := commands.Login(TestCtx, zitadelOp)
+		err := commands.Login(TestCtx, zitadelOp, false)
 		errCh <- err
 	}()
 
@@ -414,7 +414,7 @@ func TestEndToEndSSHAsUnprivilegedUser(t *testing.T) {
 	errCh := make(chan error)
 	t.Log("------- call login cmd ------")
 	go func() {
-		err := commands.Login(TestCtx, zitadelOp)
+		err := commands.Login(TestCtx, zitadelOp, false)
 		errCh <- err
 	}()
 
@@ -527,7 +527,7 @@ func TestEndToEndSSHWithRefresh(t *testing.T) {
 	defer cancelRefresh()
 	t.Log("------- call login cmd ------")
 	go func() {
-		err := commands.LoginWithRefresh(refreshCtx, pulseZitadelOp)
+		err := commands.LoginWithRefresh(refreshCtx, pulseZitadelOp, false)
 		errCh <- err
 	}()
 


### PR DESCRIPTION
Add option to print the contents of the id_token for `opkssh login`

Fixes #97 