### PR TITLE
Allow user to specify key path

### DIFF
--- a/main.go
+++ b/main.go
@@ -123,6 +123,7 @@ Arguments:
 	var providerArg string
 	var disableBrowserOpenArg bool
 	var printIdTokenArg bool
+	var keyPathArg string
 	loginCmd := &cobra.Command{
 		SilenceUsage: true,
 		Use:          "login",
@@ -157,7 +158,7 @@ Users can then SSH into servers configured to use opkssh as the AuthorizedKeysCo
 				providerFromLdFlags = providers.NewGoogleOpWithOptions(opts)
 			}
 
-			login := commands.NewLogin(autoRefresh, logDir, disableBrowserOpenArg, printIdTokenArg, providerArg, providerFromLdFlags)
+			login := commands.NewLogin(autoRefresh, logDir, disableBrowserOpenArg, printIdTokenArg, providerArg, keyPathArg, providerFromLdFlags)
 			if err := login.Run(ctx); err != nil {
 				log.Println("Error executing login command:", err)
 				return err
@@ -172,6 +173,7 @@ Users can then SSH into servers configured to use opkssh as the AuthorizedKeysCo
 	loginCmd.Flags().BoolVar(&disableBrowserOpenArg, "disable-browser-open", false, "Set this flag to disable opening the browser. Useful for choosing the browser you want to use.")
 	loginCmd.Flags().BoolVar(&printIdTokenArg, "print-id-token", false, "Set this flag to print out the contents of the id_token. Useful for inspecting claims.")
 	loginCmd.Flags().StringVar(&providerArg, "provider", "", "OpenID Provider specification in the format: <issuer>,<client_id> or <issuer>,<client_id>,<client_secret>")
+	loginCmd.Flags().StringVarP(&keyPathArg, "private-key-file", "i", "", "Path where private keys is written.")
 	rootCmd.AddCommand(loginCmd)
 
 	readhomeCmd := &cobra.Command{

--- a/test/integration/integration.go
+++ b/test/integration/integration.go
@@ -105,16 +105,26 @@ func WaitForServer(ctx context.Context, url string, timeout time.Duration) error
 // locations. If found, the parsed public SSH key and path to its secret key is
 // returned. Otherwise, an error is returned if no valid OPK SSH key could be
 // found.
-func GetOPKSshKey() (ssh.PublicKey, string, error) {
-	// Get user's SSH path
-	homePath, err := os.UserHomeDir()
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to get user's home directory: %w", err)
-	}
-	sshPath := filepath.Join(homePath, ".ssh")
+func GetOPKSshKey(seckeyPath string) (ssh.PublicKey, string, error) {
+	var expectedSSHSecKeyFilePaths []string
+	var sshPath string
 
-	// Find a valid OPK SSH key at one of the expected locations
-	expectedSSHSecKeyFilePaths := []string{"id_ecdsa", "id_dsa"}
+	if seckeyPath != "" {
+		sshPath = filepath.Dir(seckeyPath)
+		expectedSSHSecKeyFilePaths = []string{filepath.Base(seckeyPath)}
+
+	} else {
+		// Get user's SSH path
+		homePath, err := os.UserHomeDir()
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to get user's home directory: %w", err)
+		}
+		sshPath = filepath.Join(homePath, ".ssh")
+
+		// Find a valid OPK SSH key at one of the expected locations
+		expectedSSHSecKeyFilePaths = []string{"id_ecdsa", "id_dsa"}
+	}
+
 	var pubKey ssh.PublicKey
 	var secKeyFilePath string
 	for _, secKeyFilePath = range expectedSSHSecKeyFilePaths {

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -49,7 +50,7 @@ func TestLogin(t *testing.T) {
 	opkProvider, loginURL, err := opServer.OpkProvider()
 	require.NoError(t, err, "failed to create OPK provider")
 	go func() {
-		err := commands.Login(TestCtx, opkProvider, false)
+		err := commands.Login(TestCtx, opkProvider, false, "")
 		errCh <- err
 	}()
 
@@ -72,7 +73,76 @@ func TestLogin(t *testing.T) {
 	}
 
 	// Expect to find OPK SSH key is written to disk
-	pubKey, secKeyFilePath, err := GetOPKSshKey()
+	pubKey, secKeyFilePath, err := GetOPKSshKey("")
+	require.NoError(t, err)
+	require.Equal(t, ssh.CertAlgoECDSA256v01, pubKey.Type(), "expected SSH public key to be an ecdsa-sha2-nistp256 certificate")
+
+	// Parse the private key and check that it is the private key for the public
+	// key above by signing and verifying a message
+	secKeyBytes, err := os.ReadFile(secKeyFilePath)
+	require.NoErrorf(t, err, "failed to read SSH secret key at expected path %s", secKeyFilePath)
+	secKey, err := ssh.ParsePrivateKey(secKeyBytes)
+	require.NoError(t, err, "failed to parse SSH private key")
+	msg := []byte("test")
+	sig, err := secKey.Sign(rand.Reader, msg)
+	require.NoError(t, err, "failed to sign message using parsed SSH private key")
+	require.NoError(t, pubKey.Verify(msg, sig), "failed to verify message using parsed OPK SSH public key")
+}
+
+func TestLoginCustomKeyPath(t *testing.T) {
+	// Check that user can login and that valid openpubkey keys are written to
+	// the correct places on disk
+
+	// Setup fake OIDC server on localhost
+	t.Log("------- setup OIDC server on localhost ------")
+	opServer, err := NewFakeOpServer()
+	require.NoError(t, err, "failed to create fake OIDC server")
+	defer opServer.Close()
+	t.Logf("OP server running at %s", opServer.URL)
+
+	// Call login
+	t.Log("------- call login cmd ------")
+	errCh := make(chan error)
+	opkProvider, loginURL, err := opServer.OpkProvider()
+	require.NoError(t, err, "failed to create OPK provider")
+
+	homePath, err := os.UserHomeDir()
+
+	require.NoError(t, err)
+
+	sshPath := filepath.Join(homePath, ".ssh")
+
+	// Make ~/.ssh if folder does not exist
+	err = os.MkdirAll(sshPath, os.ModePerm)
+	require.NoError(t, err)
+
+	seckeyPath := filepath.Join(sshPath, "opkssh-key")
+
+	go func() {
+		err := commands.Login(TestCtx, opkProvider, false, seckeyPath)
+		errCh <- err
+	}()
+
+	// Wait for auth callback server on localhost to come up. It should come up
+	// when login command is called
+	timeoutErr := WaitForServer(TestCtx, fmt.Sprintf("%s://%s", loginURL.Scheme, loginURL.Host), LoginCallbackServerTimeout)
+	require.NoError(t, timeoutErr, "login callback server took too long to startup")
+
+	// Do OIDC login
+	DoOidcInteractiveLogin(t, nil, loginURL.String(), "test-user@localhost", "verysecure")
+
+	// Wait for interactive login to complete and assert no error occurred
+	timeoutCtx, cancel := context.WithTimeout(TestCtx, 3*time.Second)
+	defer cancel()
+	select {
+	case loginErr := <-errCh:
+		require.NoError(t, loginErr, "failed login")
+	case <-timeoutCtx.Done():
+		t.Fatal(timeoutCtx.Err())
+	}
+
+	// Expect to find OPK SSH key is written to disk
+	pubKey, secKeyFilePath, err := GetOPKSshKey(seckeyPath)
 	require.NoError(t, err)
 	require.Equal(t, ssh.CertAlgoECDSA256v01, pubKey.Type(), "expected SSH public key to be an ecdsa-sha2-nistp256 certificate")
 

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -319,7 +319,7 @@ func TestEndToEndSSH(t *testing.T) {
 	errCh := make(chan error)
 	t.Log("------- call login cmd ------")
 	go func() {
-		err := commands.Login(TestCtx, zitadelOp, false)
+		err := commands.Login(TestCtx, zitadelOp, false, "")
 		errCh <- err
 	}()
 
@@ -344,7 +344,7 @@ func TestEndToEndSSH(t *testing.T) {
 	}
 
 	// Expect to find OPK SSH key is written to disk
-	pubKey, secKeyFilePath, err := GetOPKSshKey()
+	pubKey, secKeyFilePath, err := GetOPKSshKey("")
 	require.NoError(t, err, "expected to find OPK ssh key written to disk")
 
 	// Create OPK SSH signer using the found OPK SSH key on disk
@@ -414,7 +414,7 @@ func TestEndToEndSSHAsUnprivilegedUser(t *testing.T) {
 	errCh := make(chan error)
 	t.Log("------- call login cmd ------")
 	go func() {
-		err := commands.Login(TestCtx, zitadelOp, false)
+		err := commands.Login(TestCtx, zitadelOp, false, "")
 		errCh <- err
 	}()
 
@@ -439,7 +439,7 @@ func TestEndToEndSSHAsUnprivilegedUser(t *testing.T) {
 	}
 
 	// Expect to find OPK SSH key is written to disk
-	pubKey, secKeyFilePath, err := GetOPKSshKey()
+	pubKey, secKeyFilePath, err := GetOPKSshKey("")
 	require.NoError(t, err, "expected to find OPK ssh key written to disk")
 
 	// Create OPK SSH signer using the found OPK SSH key on disk
@@ -527,7 +527,7 @@ func TestEndToEndSSHWithRefresh(t *testing.T) {
 	defer cancelRefresh()
 	t.Log("------- call login cmd ------")
 	go func() {
-		err := commands.LoginWithRefresh(refreshCtx, pulseZitadelOp, false)
+		err := commands.LoginWithRefresh(refreshCtx, pulseZitadelOp, false, "")
 		errCh <- err
 	}()
 
@@ -562,7 +562,7 @@ func TestEndToEndSSHWithRefresh(t *testing.T) {
 	defer findKeyCancel()
 	t.Logf("Waiting for login process to write an OPK ssh key to disk...")
 	err = TryFunc(findKeyCtx, func() error {
-		pubKey, secKeyFilePath, err = GetOPKSshKey()
+		pubKey, secKeyFilePath, err = GetOPKSshKey("")
 		return err
 	})
 	require.NoError(t, err, "expected to find OPK ssh key written to disk")
@@ -625,7 +625,7 @@ func TestEndToEndSSHWithRefresh(t *testing.T) {
 	defer findRefreshedKeyCancel()
 	t.Logf("Waiting for refresh process to write an OPK ssh key to disk...")
 	err = TryFunc(findRefreshedKeyCtx, func() error {
-		pubKey, secKeyFilePath, err = GetOPKSshKey()
+		pubKey, secKeyFilePath, err = GetOPKSshKey("")
 		return err
 	})
 	require.NoError(t, err, "expected to find OPK ssh key written to disk after refresh")


### PR DESCRIPTION
Allow user to specify path where private key is generated

e.g.

```bash
opkssh login -i ~/.ssh/opkssh-key
```

Fixes #89 