### PR TITLE
Adds unitests, removes client config

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,30 +247,22 @@ chown {USER}:{USER} /home/{USER}/.opk/auth_id
 chmod 600 /home/{USER}/.opk/auth_id
 ```
 
-### `~/.opksshrc`
+### Environment Variables
 
-This file is used by `opkssh login` to automatically set the environment variables that are used by the opkssh login command.
-
-It is not created automatically.
-If you want to make use of it, you must create it.
-Here is sample `~/.opksshrc` file:
-
-```bash
-OPKSSH_DEFAULT=WEBCHOOSER
-OPKSSH_PROVIDERS=google,https://accounts.google.com,206584157355-7cbe4s640tvm7naoludob4ut1emii7sf.apps.googleusercontent.com,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;microsoft,https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0,096ce0a3-5e72-4da8-9c86-12924b294a01;gitlab,https://gitlab.com,8d8b7024572c7fd501f64374dec6bba37096783dfcd792b3988104be08cb6923
-```
-
-You can edit this file to add or remove OpenID Providers. For example :
-
-```bash
-OPKSSH_PROVIDERS=google,https:[...]
-OPKSSH_PROVIDERS=$OPKSSH_PROVIDERS;authentik,https://authentik.io/application/o/opkssh/,client_id,,openid profile email
-```
+`opkssh login` reads from environment variables to determine which which provider to use.
 
 The OPKSSH_PROVIDERS variable follow this format ;
 `{alias},{issuer},{client_id},{client_secret},{scope};{alias},{issuer},{client_id},{client_secret},{scope}...`
 
-The OPKSSH_DEFAULT can be set to one of the provider's alias to set the default provider to use when running `opkssh login`. WEBCHOOSER will open a browser window to select the provider.
+```bash
+export OPKSSH_DEFAULT=WEBCHOOSER
+export OPKSSH_PROVIDERS=google,https://accounts.google.com,206584157355-7cbe4s640tvm7naoludob4ut1emii7sf.apps.googleusercontent.com,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;microsoft,https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0,096ce0a3-5e72-4da8-9c86-12924b294a01;gitlab,https://gitlab.com,8d8b7024572c7fd501f64374dec6bba37096783dfcd792b3988104be08cb6923
+export OPKSSH_PROVIDERS=$OPKSSH_PROVIDERS;authentik,https://authentik.io/application/o/opkssh/,client_id,,openid profile email
+```
+
+The OPKSSH_DEFAULT can be set to one of the provider's alias to set the default provider to use when running `opkssh login`.
+WEBCHOOSER will open a browser window to select the provider.
+
 ### AuthorizedKeysCommandUser
 
 We use a low privilege user for the SSH AuthorizedKeysCommandUser.

--- a/commands/login.go
+++ b/commands/login.go
@@ -54,7 +54,6 @@ type LoginCmd struct {
 	printIdTokenArg       bool
 	keyPathArg            string
 	providerArg           string
-	providerFromLdFlags   providers.OpenIdProvider
 	providerAlias         string
 	pkt                   *pktoken.PKToken
 	signer                crypto.Signer
@@ -64,8 +63,7 @@ type LoginCmd struct {
 }
 
 func NewLogin(autoRefresh bool, logDir string, disableBrowserOpenArg bool, printIdTokenArg bool,
-	providerArg string, keyPathArg string, providerFromLdFlags providers.OpenIdProvider,
-	providerAlias string) *LoginCmd {
+	providerArg string, keyPathArg string, providerAlias string) *LoginCmd {
 
 	return &LoginCmd{
 		autoRefresh:           autoRefresh,
@@ -74,7 +72,6 @@ func NewLogin(autoRefresh bool, logDir string, disableBrowserOpenArg bool, print
 		printIdTokenArg:       printIdTokenArg,
 		keyPathArg:            keyPathArg,
 		providerArg:           providerArg,
-		providerFromLdFlags:   providerFromLdFlags,
 		providerAlias:         providerAlias,
 	}
 }
@@ -142,8 +139,6 @@ func (l *LoginCmd) setup() (client.OpenIdProvider, *choosers.WebChooser, error) 
 		if err != nil {
 			return nil, nil, fmt.Errorf("error creating provider from config: %w", err)
 		}
-	} else if l.providerFromLdFlags != nil {
-		provider = l.providerFromLdFlags
 	} else {
 		var err error
 

--- a/commands/login.go
+++ b/commands/login.go
@@ -94,7 +94,7 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 		log.SetOutput(os.Stdout)
 	}
 
-	provider, chooser, err := l.setup(ctx)
+	provider, chooser, err := l.setup()
 	if err != nil {
 		return err
 	}
@@ -126,7 +126,7 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 	return nil
 }
 
-func (l *LoginCmd) setup(ctx context.Context) (client.OpenIdProvider, *choosers.WebChooser, error) {
+func (l *LoginCmd) setup() (client.OpenIdProvider, *choosers.WebChooser, error) {
 	openBrowser := !l.disableBrowserOpenArg
 
 	// If the user has supplied commandline arguments for the provider, use those instead of the web chooser

--- a/commands/login.go
+++ b/commands/login.go
@@ -104,7 +104,7 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 	if l.overrideProvider != nil {
 		provider = *l.overrideProvider
 	} else {
-		provider, chooser, err := l.determineProvider()
+		op, chooser, err := l.determineProvider()
 		if err != nil {
 			return err
 		}
@@ -113,7 +113,9 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 			if err != nil {
 				return fmt.Errorf("error choosing provider: %w", err)
 			}
-		} else if provider == nil {
+		} else if op != nil {
+			provider = op
+		} else {
 			return fmt.Errorf("no provider found") // Either the provider or the chooser must be set. If this occurs we have a bug in the code.
 		}
 	}

--- a/commands/login.go
+++ b/commands/login.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"log"
 	"os"
+
 	"path/filepath"
 	"strings"
 	"time"
@@ -40,14 +41,20 @@ import (
 	"github.com/openpubkey/openpubkey/providers"
 	"github.com/openpubkey/openpubkey/util"
 	"github.com/openpubkey/opkssh/sshcert"
+	"github.com/spf13/afero"
 	"golang.org/x/crypto/ssh"
 )
+
+const WEBCHOOSER_ALIAS = "WEBCHOOSER"
+const OPKSSH_DEFAULT_ENVVAR = "OPKSSH_DEFAULT"
+const OPKSSH_PROVIDERS_ENVVAR = "OPKSSH_PROVIDERS"
 
 var DefaultProviderList = "google,https://accounts.google.com,206584157355-7cbe4s640tvm7naoludob4ut1emii7sf.apps.googleusercontent.com,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;" +
 	"microsoft,https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0,096ce0a3-5e72-4da8-9c86-12924b294a01;" +
 	"gitlab,https://gitlab.com,8d8b7024572c7fd501f64374dec6bba37096783dfcd792b3988104be08cb6923"
 
 type LoginCmd struct {
+	Fs                    afero.Fs
 	autoRefresh           bool
 	logDir                string
 	disableBrowserOpenArg bool
@@ -55,6 +62,7 @@ type LoginCmd struct {
 	keyPathArg            string
 	providerArg           string
 	providerAlias         string
+	overrideProvider      *providers.OpenIdProvider // Used in tests to override the provider to inject a mock provider
 	pkt                   *pktoken.PKToken
 	signer                crypto.Signer
 	alg                   jwa.SignatureAlgorithm
@@ -66,6 +74,7 @@ func NewLogin(autoRefresh bool, logDir string, disableBrowserOpenArg bool, print
 	providerArg string, keyPathArg string, providerAlias string) *LoginCmd {
 
 	return &LoginCmd{
+		Fs:                    afero.NewOsFs(),
 		autoRefresh:           autoRefresh,
 		logDir:                logDir,
 		disableBrowserOpenArg: disableBrowserOpenArg,
@@ -80,7 +89,7 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 	// If a log directory was provided, write any logs to a file in that directory AND stdout
 	if l.logDir != "" {
 		logFilePath := filepath.Join(l.logDir, "opkssh.log")
-		logFile, err := os.OpenFile(logFilePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0660)
+		logFile, err := l.Fs.OpenFile(logFilePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0660)
 		if err != nil {
 			log.Printf("Failed to open log for writing: %v \n", err)
 		}
@@ -91,23 +100,28 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 		log.SetOutput(os.Stdout)
 	}
 
-	provider, chooser, err := l.setup()
-	if err != nil {
-		return err
-	}
-	if chooser != nil {
-		provider, err = chooser.ChooseOp(ctx)
+	var provider providers.OpenIdProvider
+	if l.overrideProvider != nil {
+		provider = *l.overrideProvider
+	} else {
+		provider, chooser, err := l.determineProvider()
 		if err != nil {
-			return fmt.Errorf("error choosing provider: %w", err)
+			return err
 		}
-	} else if provider == nil {
-		return fmt.Errorf("no provider found") // Either the provider or the chooser must be set. If this occurs we have a bug in the code.
+		if chooser != nil {
+			provider, err = chooser.ChooseOp(ctx)
+			if err != nil {
+				return fmt.Errorf("error choosing provider: %w", err)
+			}
+		} else if provider == nil {
+			return fmt.Errorf("no provider found") // Either the provider or the chooser must be set. If this occurs we have a bug in the code.
+		}
 	}
 
 	// Execute login command
 	if l.autoRefresh {
 		if providerRefreshable, ok := provider.(providers.RefreshableOpenIdProvider); ok {
-			err := LoginWithRefresh(ctx, providerRefreshable, l.printIdTokenArg, l.keyPathArg)
+			err := l.LoginWithRefresh(ctx, providerRefreshable, l.printIdTokenArg, l.keyPathArg)
 			if err != nil {
 				return fmt.Errorf("error logging in: %w", err)
 			}
@@ -115,7 +129,7 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 			return fmt.Errorf("supplied OpenID Provider (%v) does not support auto-refresh and auto-refresh argument set to true", provider.Issuer())
 		}
 	} else {
-		err := Login(ctx, provider, l.printIdTokenArg, l.keyPathArg)
+		err := l.Login(ctx, provider, l.printIdTokenArg, l.keyPathArg)
 		if err != nil {
 			return fmt.Errorf("error logging in: %w", err)
 		}
@@ -123,7 +137,7 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 	return nil
 }
 
-func (l *LoginCmd) setup() (client.OpenIdProvider, *choosers.WebChooser, error) {
+func (l *LoginCmd) determineProvider() (providers.OpenIdProvider, *choosers.WebChooser, error) {
 	openBrowser := !l.disableBrowserOpenArg
 
 	// If the user has supplied commandline arguments for the provider, use those instead of the web chooser
@@ -143,9 +157,9 @@ func (l *LoginCmd) setup() (client.OpenIdProvider, *choosers.WebChooser, error) 
 		var err error
 
 		// Get the default provider from the env variable
-		defaultProvider, ok := os.LookupEnv("OPKSSH_DEFAULT")
+		defaultProvider, ok := os.LookupEnv(OPKSSH_DEFAULT_ENVVAR)
 		if !ok || defaultProvider == "" {
-			defaultProvider = "WEBCHOOSER"
+			defaultProvider = WEBCHOOSER_ALIAS
 		}
 		providerConfigs, err := GetProvidersConfigFromEnv()
 
@@ -153,7 +167,7 @@ func (l *LoginCmd) setup() (client.OpenIdProvider, *choosers.WebChooser, error) 
 			return nil, nil, fmt.Errorf("error getting provider config from env: %w", err)
 		}
 
-		if l.providerAlias != "" && l.providerAlias != "WEBCHOOSER" {
+		if l.providerAlias != "" && l.providerAlias != WEBCHOOSER_ALIAS {
 			config, ok := providerConfigs[l.providerAlias]
 			if !ok {
 				return nil, nil, fmt.Errorf("error getting provider config for alias %s", l.providerAlias)
@@ -163,7 +177,7 @@ func (l *LoginCmd) setup() (client.OpenIdProvider, *choosers.WebChooser, error) 
 				return nil, nil, fmt.Errorf("error creating provider from config: %w", err)
 			}
 		} else {
-			if defaultProvider != "WEBCHOOSER" {
+			if defaultProvider != WEBCHOOSER_ALIAS {
 				config, ok := providerConfigs[defaultProvider]
 				if !ok {
 					return nil, nil, fmt.Errorf("error getting provider config for alias %s", defaultProvider)
@@ -192,7 +206,7 @@ func (l *LoginCmd) setup() (client.OpenIdProvider, *choosers.WebChooser, error) 
 	return provider, nil, nil
 }
 
-func login(ctx context.Context, provider client.OpenIdProvider, printIdToken bool, seckeyPath string) (*LoginCmd, error) {
+func (l *LoginCmd) login(ctx context.Context, provider providers.OpenIdProvider, printIdToken bool, seckeyPath string) (*LoginCmd, error) {
 	var err error
 	alg := jwa.ES256
 	signer, err := util.GenKeyPair(alg)
@@ -221,12 +235,12 @@ func login(ctx context.Context, provider client.OpenIdProvider, printIdToken boo
 	// Write ssh secret key and public key to filesystem
 	if seckeyPath != "" {
 		// If we have set seckeyPath then write it there
-		if err := writeKeys(seckeyPath, seckeyPath+".pub", seckeySshPem, certBytes); err != nil {
+		if err := l.writeKeys(seckeyPath, seckeyPath+".pub", seckeySshPem, certBytes); err != nil {
 			return nil, fmt.Errorf("failed to write SSH keys to filesystem: %w", err)
 		}
 	} else {
 		// If keyPath isn't set then write it to the default location
-		if err := writeKeysToSSHDir(seckeySshPem, certBytes); err != nil {
+		if err := l.writeKeysToSSHDir(seckeySshPem, certBytes); err != nil {
 			return nil, fmt.Errorf("failed to write SSH keys to filesystem: %w", err)
 		}
 	}
@@ -258,8 +272,8 @@ func login(ctx context.Context, provider client.OpenIdProvider, printIdToken boo
 
 // Login performs the OIDC login procedure and creates the SSH certs/keys in the
 // default SSH key location.
-func Login(ctx context.Context, provider client.OpenIdProvider, printIdToken bool, seckeyPath string) error {
-	_, err := login(ctx, provider, printIdToken, seckeyPath)
+func (l *LoginCmd) Login(ctx context.Context, provider providers.OpenIdProvider, printIdToken bool, seckeyPath string) error {
+	_, err := l.login(ctx, provider, printIdToken, seckeyPath)
 	return err
 }
 
@@ -268,8 +282,8 @@ func Login(ctx context.Context, provider client.OpenIdProvider, printIdToken boo
 // the PKT (and create new SSH certs) indefinitely as its token expires. This
 // function only returns if it encounters an error or if the supplied context is
 // cancelled.
-func LoginWithRefresh(ctx context.Context, provider providers.RefreshableOpenIdProvider, printIdToken bool, seckeyPath string) error {
-	if loginResult, err := login(ctx, provider, printIdToken, seckeyPath); err != nil {
+func (l *LoginCmd) LoginWithRefresh(ctx context.Context, provider providers.RefreshableOpenIdProvider, printIdToken bool, seckeyPath string) error {
+	if loginResult, err := l.login(ctx, provider, printIdToken, seckeyPath); err != nil {
 		return err
 	} else {
 		var claims struct {
@@ -305,12 +319,12 @@ func LoginWithRefresh(ctx context.Context, provider providers.RefreshableOpenIdP
 			// Write ssh secret key and public key to filesystem
 			if seckeyPath != "" {
 				// If we have set seckeyPath then write it there
-				if err := writeKeys(seckeyPath, seckeyPath+".pub", seckeySshPem, certBytes); err != nil {
+				if err := l.writeKeys(seckeyPath, seckeyPath+".pub", seckeySshPem, certBytes); err != nil {
 					return fmt.Errorf("failed to write SSH keys to filesystem: %w", err)
 				}
 			} else {
 				// If keyPath isn't set then write it to the default location
-				if err := writeKeysToSSHDir(seckeySshPem, certBytes); err != nil {
+				if err := l.writeKeysToSSHDir(seckeySshPem, certBytes); err != nil {
 					return fmt.Errorf("failed to write SSH keys to filesystem: %w", err)
 				}
 			}
@@ -368,7 +382,7 @@ func createSSHCert(pkt *pktoken.PKToken, signer crypto.Signer, principals []stri
 	return certBytes, seckeySshBytes, nil
 }
 
-func writeKeysToSSHDir(seckeySshPem []byte, certBytes []byte) error {
+func (l *LoginCmd) writeKeysToSSHDir(seckeySshPem []byte, certBytes []byte) error {
 	homePath, err := os.UserHomeDir()
 	if err != nil {
 		return err
@@ -376,7 +390,7 @@ func writeKeysToSSHDir(seckeySshPem []byte, certBytes []byte) error {
 	sshPath := filepath.Join(homePath, ".ssh")
 
 	// Make ~/.ssh if folder does not exist
-	err = os.MkdirAll(sshPath, os.ModePerm)
+	err = l.Fs.MkdirAll(sshPath, os.ModePerm)
 	if err != nil {
 		return err
 	}
@@ -391,14 +405,15 @@ func writeKeysToSSHDir(seckeySshPem []byte, certBytes []byte) error {
 		seckeyPath := filepath.Join(sshPath, keyFilename)
 		pubkeyPath := seckeyPath + ".pub"
 
-		if !fileExists(seckeyPath) {
+		if !l.fileExists(seckeyPath) {
 			// If ssh key file does not currently exist, we don't have to worry about overwriting it
-			return writeKeys(seckeyPath, pubkeyPath, seckeySshPem, certBytes)
-		} else if !fileExists(pubkeyPath) {
+			return l.writeKeys(seckeyPath, pubkeyPath, seckeySshPem, certBytes)
+		} else if !l.fileExists(pubkeyPath) {
 			continue
 		} else {
 			// If the ssh key file does exist, check if it was generated by openpubkey, if it was then it is safe to overwrite
-			sshPubkey, err := os.ReadFile(pubkeyPath)
+			afs := &afero.Afero{Fs: l.Fs}
+			sshPubkey, err := afs.ReadFile(pubkeyPath)
 			if err != nil {
 				log.Println("Failed to read:", pubkeyPath)
 				continue
@@ -411,16 +426,17 @@ func writeKeysToSSHDir(seckeySshPem []byte, certBytes []byte) error {
 
 			// If the key comment is "openpubkey" then we generated it
 			if comment == "openpubkey" {
-				return writeKeys(seckeyPath, pubkeyPath, seckeySshPem, certBytes)
+				return l.writeKeys(seckeyPath, pubkeyPath, seckeySshPem, certBytes)
 			}
 		}
 	}
 	return fmt.Errorf("no default ssh key file free for openpubkey")
 }
 
-func writeKeys(seckeyPath string, pubkeyPath string, seckeySshPem []byte, certBytes []byte) error {
+func (l *LoginCmd) writeKeys(seckeyPath string, pubkeyPath string, seckeySshPem []byte, certBytes []byte) error {
 	// Write ssh secret key to filesystem
-	if err := os.WriteFile(seckeyPath, seckeySshPem, 0600); err != nil {
+	afs := &afero.Afero{Fs: l.Fs}
+	if err := afs.WriteFile(seckeyPath, seckeySshPem, 0600); err != nil {
 		return err
 	}
 
@@ -428,11 +444,11 @@ func writeKeys(seckeyPath string, pubkeyPath string, seckeySshPem []byte, certBy
 
 	certBytes = append(certBytes, []byte(" openpubkey")...)
 	// Write ssh public key (certificate) to filesystem
-	return os.WriteFile(pubkeyPath, certBytes, 0644)
+	return afs.WriteFile(pubkeyPath, certBytes, 0644)
 }
 
-func fileExists(fPath string) bool {
-	_, err := os.Open(fPath)
+func (l *LoginCmd) fileExists(fPath string) bool {
+	_, err := l.Fs.Open(fPath)
 	return !errors.Is(err, os.ErrNotExist)
 }
 
@@ -515,7 +531,7 @@ func NewProviderConfigFromString(configStr string, hasAlias bool) (ProviderConfi
 }
 
 // NewProviderFromConfig is a function to create the provider from the config
-func NewProviderFromConfig(config ProviderConfig, openBrowser bool) (client.OpenIdProvider, error) {
+func NewProviderFromConfig(config ProviderConfig, openBrowser bool) (providers.OpenIdProvider, error) {
 
 	if config.Issuer == "" {
 		return nil, fmt.Errorf("invalid provider issuer value got (%s)", config.Issuer)
@@ -528,7 +544,7 @@ func NewProviderFromConfig(config ProviderConfig, openBrowser bool) (client.Open
 	if config.ClientID == "" {
 		return nil, fmt.Errorf("invalid provider client-ID value got (%s)", config.ClientID)
 	}
-	var provider client.OpenIdProvider
+	var provider providers.OpenIdProvider
 
 	if strings.HasPrefix(config.Issuer, "https://accounts.google.com") {
 		opts := providers.GetDefaultGoogleOpOptions()
@@ -575,7 +591,7 @@ func GetProvidersConfigFromEnv() (map[string]ProviderConfig, error) {
 	providersConfig := make(map[string]ProviderConfig)
 
 	// Get the providers from the env variable
-	providerList, ok := os.LookupEnv("OPKSSH_PROVIDERS")
+	providerList, ok := os.LookupEnv(OPKSSH_PROVIDERS_ENVVAR)
 	if !ok {
 		providerList = DefaultProviderList
 	}

--- a/commands/login_test.go
+++ b/commands/login_test.go
@@ -99,6 +99,7 @@ func TestLoginCmd(t *testing.T) {
 
 	sshPath := filepath.Join(homePath, ".ssh", "id_ecdsa")
 	secKeyBytes, err := afero.ReadFile(mockFs, sshPath)
+	require.NoError(t, err)
 	require.NotNil(t, secKeyBytes)
 	require.Contains(t, string(secKeyBytes), "-----BEGIN OPENSSH PRIVATE KEY-----")
 }

--- a/commands/login_test.go
+++ b/commands/login_test.go
@@ -195,7 +195,7 @@ func TestLoginCmd(t *testing.T) {
 				providerAlias:         tt.providerAlias,
 			}
 
-			provider, chooser, err := loginCmd.setup(context.Background())
+			provider, chooser, err := loginCmd.setup()
 			if tt.wantError {
 				require.Error(t, err, "Expected error but got none")
 				if tt.errorString != "" {

--- a/commands/login_test.go
+++ b/commands/login_test.go
@@ -47,6 +47,8 @@ const providerIssuer3 = "https://openidprovider.openidconnect/tokens-3/"
 const providerArg3 = providerIssuer3 + ",client-id91011,,"
 const providerStr3 = providerAlias3 + "," + providerArg3
 
+const allProvidersStr = providerStr1 + ";" + providerStr2 + ";" + providerStr3
+
 func MockPKToken(t *testing.T) (*pktoken.PKToken, crypto.Signer) {
 	alg := jwa.ES256
 	signer, err := util.GenKeyPair(alg)
@@ -78,60 +80,31 @@ func ProviderFromString(t *testing.T, providerString string) client.OpenIdProvid
 }
 
 func TestLoginCmd(t *testing.T) {
-
-	providerConfig3, err := NewProviderConfigFromString(providerStr3, true)
-	require.NoError(t, err)
-	provider3, err := NewProviderFromConfig(providerConfig3, false)
-	require.NoError(t, err)
-
-	allProvidersStr := providerStr1 + ";" + providerStr2 + ";" + providerStr3
-
 	tests := []struct {
-		name                string
-		envVars             map[string]string
-		providerArg         string
-		providerFromLdFlags providers.OpenIdProvider
-		providerAlias       string
-		wantIssuer          string
-		wantChooser         string
-		wantError           bool
-		errorString         string
+		name          string
+		envVars       map[string]string
+		providerArg   string
+		providerAlias string
+		wantIssuer    string
+		wantChooser   string
+		wantError     bool
+		errorString   string
 	}{
 		{
-			name:                "Good path with env vars",
-			envVars:             map[string]string{"OPKSSH_DEFAULT": providerAlias1, "OPKSSH_PROVIDERS": providerStr1},
-			providerArg:         "",
-			providerFromLdFlags: nil,
-			providerAlias:       "",
-			wantIssuer:          providerIssuer1,
-			wantError:           false,
+			name:          "Good path with env vars",
+			envVars:       map[string]string{"OPKSSH_DEFAULT": providerAlias1, "OPKSSH_PROVIDERS": providerStr1},
+			providerArg:   "",
+			providerAlias: "",
+			wantIssuer:    providerIssuer1,
+			wantError:     false,
 		},
 		{
-			name:                "Good path with env vars and provider arg (provider arg takes precedence)",
-			envVars:             map[string]string{"OPKSSH_DEFAULT": providerAlias1, "OPKSSH_PROVIDERS": providerStr1},
-			providerArg:         providerArg2,
-			providerFromLdFlags: nil,
-			providerAlias:       "",
-			wantIssuer:          providerIssuer2,
-			wantError:           false,
-		},
-		{
-			name:                "Good path with env vars, provider arg and providerFromLdFlags (provider arg takes precedence)",
-			envVars:             map[string]string{"OPKSSH_DEFAULT": providerAlias1, "OPKSSH_PROVIDERS": providerStr1},
-			providerArg:         providerArg2,
-			providerFromLdFlags: provider3,
-			providerAlias:       "",
-			wantIssuer:          providerIssuer2,
-			wantError:           false,
-		},
-		{
-			name:                "Good path with env vars and providerFromLdFlags (providerFromLdFlags takes precedence)",
-			envVars:             map[string]string{"OPKSSH_DEFAULT": providerAlias1, "OPKSSH_PROVIDERS": providerStr1},
-			providerArg:         "",
-			providerFromLdFlags: provider3,
-			providerAlias:       "",
-			wantIssuer:          providerIssuer3,
-			wantError:           false,
+			name:          "Good path with env vars and provider arg (provider arg takes precedence)",
+			envVars:       map[string]string{"OPKSSH_DEFAULT": providerAlias1, "OPKSSH_PROVIDERS": providerStr1},
+			providerArg:   providerArg2,
+			providerAlias: "",
+			wantIssuer:    providerIssuer2,
+			wantError:     false,
 		},
 		{
 			name:          "Good path with env vars and no alias",
@@ -191,7 +164,6 @@ func TestLoginCmd(t *testing.T) {
 			loginCmd := LoginCmd{
 				disableBrowserOpenArg: true,
 				providerArg:           tt.providerArg,
-				providerFromLdFlags:   tt.providerFromLdFlags,
 				providerAlias:         tt.providerAlias,
 			}
 
@@ -227,6 +199,16 @@ func TestLoginCmd(t *testing.T) {
 	}
 }
 
+func TestProviderConfigFromString(t *testing.T) {
+	providerConfig3, err := NewProviderConfigFromString(providerStr3, true)
+	require.NoError(t, err)
+	provider3, err := NewProviderFromConfig(providerConfig3, false)
+	require.NoError(t, err)
+
+	require.NotNil(t, provider3)
+	require.Equal(t, provider3.Issuer(), providerIssuer3)
+}
+
 func TestNewLogin(t *testing.T) {
 	autoRefresh := false
 	logDir := "./testdata"
@@ -234,10 +216,9 @@ func TestNewLogin(t *testing.T) {
 	printIdTokenArg := false
 	providerArg := ""
 	keyPathArg := ""
-	providerFromLdFlags := ProviderFromString(t, providerStr3)
 	providerAlias := ""
 
-	loginCmd := NewLogin(autoRefresh, logDir, disableBrowserOpenArg, printIdTokenArg, providerArg, keyPathArg, providerFromLdFlags, providerAlias)
+	loginCmd := NewLogin(autoRefresh, logDir, disableBrowserOpenArg, printIdTokenArg, providerArg, keyPathArg, providerAlias)
 	require.NotNil(t, loginCmd)
 }
 

--- a/main.go
+++ b/main.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/openpubkey/openpubkey/providers"
 	"github.com/openpubkey/opkssh/commands"
 	"github.com/openpubkey/opkssh/policy"
 	"github.com/openpubkey/opkssh/policy/files"
@@ -37,12 +36,8 @@ import (
 
 var (
 	// These can be overridden at build time using ldflags. For example:
-	// go build -v -o /usr/local/bin/opkssh -ldflags "-X main.issuer=http://oidc.local:${ISSUER_PORT}/ -X main.clientID=web -X main.clientSecret=secret"
+	// go build -v -o /usr/local/bin/opkssh -ldflags "-X main.Version=version"
 	Version           = "unversioned"
-	issuer            = ""
-	clientID          = ""
-	clientSecret      = ""
-	redirectURIs      = ""
 	logFilePathServer = "/var/log/opkssh.log" // Remember if you change this, change it in the install script as well
 )
 
@@ -150,22 +145,12 @@ Arguments:
 				cancel()
 			}()
 
-			// If LDFlags issuer is set, build providerFromLdFlags
-			var providerFromLdFlags providers.OpenIdProvider
-			if issuer != "" {
-				opts := providers.GetDefaultGoogleOpOptions()
-				opts.Issuer = issuer
-				opts.ClientID = clientID
-				opts.ClientSecret = clientSecret
-				opts.RedirectURIs = strings.Split(redirectURIs, ",")
-				providerFromLdFlags = providers.NewGoogleOpWithOptions(opts)
-			}
 			var providerAlias string
 			if len(args) > 0 {
 				providerAlias = args[0]
 			}
 
-			login := commands.NewLogin(autoRefresh, logDir, disableBrowserOpenArg, printIdTokenArg, providerArg, keyPathArg, providerFromLdFlags, providerAlias)
+			login := commands.NewLogin(autoRefresh, logDir, disableBrowserOpenArg, printIdTokenArg, providerArg, keyPathArg, providerAlias)
 			if err := login.Run(ctx); err != nil {
 				log.Println("Error executing login command:", err)
 				return err

--- a/test/integration/fakeop.go
+++ b/test/integration/fakeop.go
@@ -33,7 +33,6 @@ import (
 	"log/slog"
 
 	"github.com/jeremija/gosubmit"
-	"github.com/openpubkey/openpubkey/client"
 	"github.com/openpubkey/openpubkey/providers"
 	"github.com/stretchr/testify/require"
 	"github.com/zitadel/oidc/v3/example/server/exampleop"
@@ -86,7 +85,7 @@ func NewFakeOpServer() (*FakeOpServer, error) {
 // The OPK provider uses this server's registered web client application's auth
 // details (clientID + clientSecret). scopes are the scopes to request when
 // performing OIDC login flow; if empty, then default scopes are used.
-func (s *FakeOpServer) OpkProvider() (client.OpenIdProvider, *url.URL, error) {
+func (s *FakeOpServer) OpkProvider() (providers.OpenIdProvider, *url.URL, error) {
 	// Find available port to run local auth callback server on when requesting
 	// tokens from the OP.
 	//

--- a/test/integration/login_test.go
+++ b/test/integration/login_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/openpubkey/opkssh/commands"
+	"github.com/spf13/afero"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
@@ -50,7 +51,8 @@ func TestLogin(t *testing.T) {
 	opkProvider, loginURL, err := opServer.OpkProvider()
 	require.NoError(t, err, "failed to create OPK provider")
 	go func() {
-		err := commands.Login(TestCtx, opkProvider, false, "")
+		loginCmd := commands.LoginCmd{Fs: afero.NewOsFs()}
+		err := loginCmd.Login(TestCtx, opkProvider, false, "")
 		errCh <- err
 	}()
 
@@ -119,7 +121,8 @@ func TestLoginCustomKeyPath(t *testing.T) {
 	seckeyPath := filepath.Join(sshPath, "opkssh-key")
 
 	go func() {
-		err := commands.Login(TestCtx, opkProvider, false, seckeyPath)
+		loginCmd := commands.LoginCmd{Fs: afero.NewOsFs()}
+		err := loginCmd.Login(TestCtx, opkProvider, false, seckeyPath)
 		errCh <- err
 	}()
 

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/openpubkey/opkssh/commands"
 	testprovider "github.com/openpubkey/opkssh/test/integration/provider"
 	"github.com/openpubkey/opkssh/test/integration/ssh_server"
+	"github.com/spf13/afero"
 
 	"github.com/melbahja/goph"
 	"github.com/stretchr/testify/assert"
@@ -319,7 +320,8 @@ func TestEndToEndSSH(t *testing.T) {
 	errCh := make(chan error)
 	t.Log("------- call login cmd ------")
 	go func() {
-		err := commands.Login(TestCtx, zitadelOp, false, "")
+		loginCmd := commands.LoginCmd{Fs: afero.NewOsFs()}
+		err := loginCmd.Login(TestCtx, zitadelOp, false, "")
 		errCh <- err
 	}()
 
@@ -414,7 +416,8 @@ func TestEndToEndSSHAsUnprivilegedUser(t *testing.T) {
 	errCh := make(chan error)
 	t.Log("------- call login cmd ------")
 	go func() {
-		err := commands.Login(TestCtx, zitadelOp, false, "")
+		loginCmd := commands.LoginCmd{Fs: afero.NewOsFs()}
+		err := loginCmd.Login(TestCtx, zitadelOp, false, "")
 		errCh <- err
 	}()
 
@@ -527,7 +530,8 @@ func TestEndToEndSSHWithRefresh(t *testing.T) {
 	defer cancelRefresh()
 	t.Log("------- call login cmd ------")
 	go func() {
-		err := commands.LoginWithRefresh(refreshCtx, pulseZitadelOp, false, "")
+		loginCmd := commands.LoginCmd{Fs: afero.NewOsFs()}
+		err := loginCmd.LoginWithRefresh(refreshCtx, pulseZitadelOp, false, "")
 		errCh <- err
 	}()
 


### PR DESCRIPTION
This PR builds on https://github.com/openpubkey/opkssh/pull/60

- It adds more unittests for client environment variables.
- Removes client config that allows automatically setting the environment variables.
- Removes ability to specify provider using ldFlags as this is better handled by environment variables and we no longer use ldFlags for this purpose in the unittests
- Allows LoginCmd run to be mocked and unittested

