### PR TITLE
Add support for ES256 OpenID Providers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/jeremija/gosubmit v0.2.7
 	github.com/lestrrat-go/jwx/v2 v2.0.21
 	github.com/melbahja/goph v1.4.0
-	github.com/openpubkey/openpubkey v0.8.0
+	github.com/openpubkey/openpubkey v0.10.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
-github.com/openpubkey/openpubkey v0.8.0 h1:nT3FHHmdqy/JK57plJ69bCCLm0WOKjRDp0WJQvtV4ss=
-github.com/openpubkey/openpubkey v0.8.0/go.mod h1:Y/dYOw3jbBJcuWQ0j7J8FSvZbtWiu56CcAK6QIsMJoo=
+github.com/openpubkey/openpubkey v0.10.0 h1:gkQkhN0qJpW2QZY4wL6LsxNTkMdT5tZT8JxVgyfL8sA=
+github.com/openpubkey/openpubkey v0.10.0/go.mod h1:Y/dYOw3jbBJcuWQ0j7J8FSvZbtWiu56CcAK6QIsMJoo=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.5/go.mod h1:wHDZ0IZX6JcBYRK1TH9bcVq8G7TLpVHYIGJRFnmPfxg=

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -172,7 +172,7 @@ func createOpkSshSigner(t *testing.T, pubKey ssh.PublicKey, secKeyFilePath strin
 // This function returns both an OPK SSH provider and an HTTP transport that has
 // been modified from the http.DefaultTransport to send requests to 127.0.0.1
 // instead of oidc.local
-func createZitadelOPKSshProvider(oidcContainerMappedPort int, authCallbackServerRedirectPort int) (zitadelOp providers.BrowserOpenIdProvider, httpTransport http.RoundTripper) {
+func createZitadelOPKSshProvider(oidcContainerMappedPort int, authCallbackServerRedirectPort int) (zitadelOp providers.RefreshableOpenIdProvider, httpTransport http.RoundTripper) {
 	// Create custom HTTP client that sends HTTP requests to the correct port
 	// and valid IP of the container running the OIDC server instead of
 	// "oidc.local" (which is an unknown name on the host machine); "oidc.local"
@@ -206,7 +206,7 @@ func createZitadelOPKSshProvider(oidcContainerMappedPort int, authCallbackServer
 		Scopes:       []string{"openid", "profile", "email", "offline_access"},
 		OpenBrowser:  false,
 		HttpClient:   &httpClient,
-	})
+	}).(providers.RefreshableOpenIdProvider)
 	return
 }
 


### PR DESCRIPTION
Bumps to new version of OpenPubkey which adds support for ES256 signed IP Tokens

Fixes #https://github.com/openpubkey/opkssh/issues/131

