### PR TITLE
Add support for hello.coop OP

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **opkssh** is a tool which enables ssh to be used with OpenID Connect allowing SSH access to be managed via identities like `alice@example.com` instead of long-lived SSH keys.
 It does not replace SSH, but instead generates SSH public keys containing PK Tokens and configures sshd to verify them. These PK Tokens contain standard [OpenID Connect ID Tokens](https://openid.net/specs/openid-connect-core-1_0.html). This protocol builds on the [OpenPubkey](https://github.com/openpubkey/openpubkey/blob/main/README.md) which adds user public keys to OpenID Connect without breaking compatibility with existing OpenID Provider.
 
-Currently opkssh is compatible with Google, Microsoft/Azure and Gitlab OpenID Providers (OP). If you have a gmail, microsoft or a gitlab account you can ssh with that account.
+Currently opkssh is compatible with Google, Microsoft/Azure, Gitlab, hello.dev, and Authelia OpenID Providers (OP). See below for the entire list. If you have a gmail, microsoft or a gitlab account you can ssh with that account.
 
 To ssh with opkssh you first need to download the opkssh binary and then run:
 
@@ -115,6 +115,7 @@ sudo opkssh add root alice@gmail.com google
 ```
 
 To allow a group, `ssh-users`, to ssh to your server as `root`, run:
+
 ```bash
 sudo opkssh add root oidc:groups:ssh-users google
 ```
@@ -191,9 +192,9 @@ Linux user accounts are typically referred to in SSH as *principals* and we cont
 - Column 2: Email address or subject ID of the user (choose one)
   - Email - the email of the identity
   - Subject ID - an unique ID for the user set by the OP. This is the `sub` claim in the ID Token.
-  - Group - the name of the group that the user is part of. This uses the `groups` claim which is presumed to 
+  - Group - the name of the group that the user is part of. This uses the `groups` claim which is presumed to
     be an array. The group identifier uses a structured identifier. I.e. `oidc:groups:{groupId}`. Replace the `groupId`
-    with the id of your group. 
+    with the id of your group.
 - Column 3: Issuer URI
 
 ```bash
@@ -278,7 +279,7 @@ or in the rare case that a client secret is required by the OpenID Provider:
 opkssh login --provider={ISSUER},{CLIENT_ID},{CLIENT_SECRET}
 ```
 
-where ISSUER, CLIENT_ID and CLIENT_SECRET correspond to the issuer client ID and client secret of the custom OpenID Provider. 
+where ISSUER, CLIENT_ID and CLIENT_SECRET correspond to the issuer client ID and client secret of the custom OpenID Provider.
 
 For example if the issuer is `https://authentik.local/application/o/opkssh/` and the client ID was `ClientID123`:
 
@@ -330,7 +331,7 @@ Such replay attacks can be ruled out by simply using a new client ID with opkssh
 
 Note that this requirement of using different client IDs for different audiences and uses is not unique to opkssh and is a best practice in OpenID Connect.
 
-### Server Configuration
+### Provider Server Configuration
 
 In the `/etc/opk/providers` file, add the OpenID Provider as you would any OpenID Provider. For example:
 
@@ -354,7 +355,6 @@ opkssh add root alice@example.com https://authentik.local/application/o/opkssh/
 | [PocketID](https://github.com/pocket-id/pocket-id) | ✅      | Create a new OIDC Client and inside the new client, check "Public client" on OIDC Client Settings                                             |
 
 Do not use Confidential/Secret mode **only** client ID is needed.
-
 
 ## More information
 

--- a/commands/login.go
+++ b/commands/login.go
@@ -55,13 +55,14 @@ var DefaultProviderList = "google,https://accounts.google.com,206584157355-7cbe4
 
 type LoginCmd struct {
 	Fs                    afero.Fs
-	autoRefresh           bool
-	logDir                string
+	autoRefreshArg        bool
+	logDirArg             string
 	disableBrowserOpenArg bool
 	printIdTokenArg       bool
 	keyPathArg            string
 	providerArg           string
-	providerAlias         string
+	providerAliasArg      string
+	verbosity             int                       // Default verbosity is 0, 1 is verbose, 2 is debug
 	overrideProvider      *providers.OpenIdProvider // Used in tests to override the provider to inject a mock provider
 	pkt                   *pktoken.PKToken
 	signer                crypto.Signer
@@ -70,25 +71,25 @@ type LoginCmd struct {
 	principals            []string
 }
 
-func NewLogin(autoRefresh bool, logDir string, disableBrowserOpenArg bool, printIdTokenArg bool,
-	providerArg string, keyPathArg string, providerAlias string) *LoginCmd {
+func NewLogin(autoRefreshArg bool, logDirArg string, disableBrowserOpenArg bool, printIdTokenArg bool,
+	providerArg string, keyPathArg string, providerAliasArg string) *LoginCmd {
 
 	return &LoginCmd{
 		Fs:                    afero.NewOsFs(),
-		autoRefresh:           autoRefresh,
-		logDir:                logDir,
+		autoRefreshArg:        autoRefreshArg,
+		logDirArg:             logDirArg,
 		disableBrowserOpenArg: disableBrowserOpenArg,
 		printIdTokenArg:       printIdTokenArg,
 		keyPathArg:            keyPathArg,
 		providerArg:           providerArg,
-		providerAlias:         providerAlias,
+		providerAliasArg:      providerAliasArg,
 	}
 }
 
 func (l *LoginCmd) Run(ctx context.Context) error {
 	// If a log directory was provided, write any logs to a file in that directory AND stdout
-	if l.logDir != "" {
-		logFilePath := filepath.Join(l.logDir, "opkssh.log")
+	if l.logDirArg != "" {
+		logFilePath := filepath.Join(l.logDirArg, "opkssh.log")
 		logFile, err := l.Fs.OpenFile(logFilePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0660)
 		if err != nil {
 			log.Printf("Failed to open log for writing: %v \n", err)
@@ -98,6 +99,10 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 		log.SetOutput(multiWriter)
 	} else {
 		log.SetOutput(os.Stdout)
+	}
+
+	if l.verbosity >= 2 {
+		log.Printf("DEBUG: running login command with args: %+v", *l)
 	}
 
 	var provider providers.OpenIdProvider
@@ -121,7 +126,7 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 	}
 
 	// Execute login command
-	if l.autoRefresh {
+	if l.autoRefreshArg {
 		if providerRefreshable, ok := provider.(providers.RefreshableOpenIdProvider); ok {
 			err := l.LoginWithRefresh(ctx, providerRefreshable, l.printIdTokenArg, l.keyPathArg)
 			if err != nil {
@@ -169,10 +174,10 @@ func (l *LoginCmd) determineProvider() (providers.OpenIdProvider, *choosers.WebC
 			return nil, nil, fmt.Errorf("error getting provider config from env: %w", err)
 		}
 
-		if l.providerAlias != "" && l.providerAlias != WEBCHOOSER_ALIAS {
-			config, ok := providerConfigs[l.providerAlias]
+		if l.providerAliasArg != "" && l.providerAliasArg != WEBCHOOSER_ALIAS {
+			config, ok := providerConfigs[l.providerAliasArg]
 			if !ok {
-				return nil, nil, fmt.Errorf("error getting provider config for alias %s", l.providerAlias)
+				return nil, nil, fmt.Errorf("error getting provider config for alias %s", l.providerAliasArg)
 			}
 			provider, err = NewProviderFromConfig(config, openBrowser)
 			if err != nil {
@@ -570,6 +575,13 @@ func NewProviderFromConfig(config ProviderConfig, openBrowser bool) (providers.O
 		opts.GQSign = false
 		opts.OpenBrowser = openBrowser
 		provider = providers.NewGitlabOpWithOptions(opts)
+	} else if strings.HasPrefix(config.Issuer, "https://issuer.hello.coop") {
+		opts := providers.GetDefaultHelloOpOptions()
+		opts.Issuer = config.Issuer
+		opts.ClientID = config.ClientID
+		opts.GQSign = false
+		opts.OpenBrowser = openBrowser
+		provider = providers.NewHelloOpWithOptions(opts)
 	} else {
 		// Generic provider - Need signing, no encryption
 		opts := providers.GetDefaultGoogleOpOptions()

--- a/commands/login.go
+++ b/commands/login.go
@@ -51,7 +51,8 @@ const OPKSSH_PROVIDERS_ENVVAR = "OPKSSH_PROVIDERS"
 
 var DefaultProviderList = "google,https://accounts.google.com,206584157355-7cbe4s640tvm7naoludob4ut1emii7sf.apps.googleusercontent.com,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;" +
 	"microsoft,https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0,096ce0a3-5e72-4da8-9c86-12924b294a01;" +
-	"gitlab,https://gitlab.com,8d8b7024572c7fd501f64374dec6bba37096783dfcd792b3988104be08cb6923"
+	"gitlab,https://gitlab.com,8d8b7024572c7fd501f64374dec6bba37096783dfcd792b3988104be08cb6923;" +
+	"hello,https://issuer.hello.coop,app_xejobTKEsDNSRd5vofKB2iay_2rN"
 
 type LoginCmd struct {
 	Fs                    afero.Fs

--- a/commands/login.go
+++ b/commands/login.go
@@ -576,7 +576,7 @@ func NewProviderFromConfig(config ProviderConfig, openBrowser bool) (providers.O
 		opts.GQSign = false
 		opts.OpenBrowser = openBrowser
 		provider = providers.NewGitlabOpWithOptions(opts)
-	} else if strings.HasPrefix(config.Issuer, "https://issuer.hello.coop") {
+	} else if config.Issuer == "https://issuer.hello.coop" {
 		opts := providers.GetDefaultHelloOpOptions()
 		opts.Issuer = config.Issuer
 		opts.ClientID = config.ClientID

--- a/main.go
+++ b/main.go
@@ -113,8 +113,8 @@ Arguments:
 	}
 	rootCmd.AddCommand(addCmd)
 
-	var autoRefresh bool
-	var logDir string
+	var autoRefreshArg bool
+	var logDirArg string
 	var providerArg string
 	var disableBrowserOpenArg bool
 	var printIdTokenArg bool
@@ -145,12 +145,12 @@ Arguments:
 				cancel()
 			}()
 
-			var providerAlias string
+			var providerAliasArg string
 			if len(args) > 0 {
-				providerAlias = args[0]
+				providerAliasArg = args[0]
 			}
 
-			login := commands.NewLogin(autoRefresh, logDir, disableBrowserOpenArg, printIdTokenArg, providerArg, keyPathArg, providerAlias)
+			login := commands.NewLogin(autoRefreshArg, logDirArg, disableBrowserOpenArg, printIdTokenArg, providerArg, keyPathArg, providerAliasArg)
 			if err := login.Run(ctx); err != nil {
 				log.Println("Error executing login command:", err)
 				return err
@@ -161,8 +161,8 @@ Arguments:
 	}
 
 	// Define flags for login.
-	loginCmd.Flags().BoolVar(&autoRefresh, "auto-refresh", false, "Automatically refresh PK token after login")
-	loginCmd.Flags().StringVar(&logDir, "log-dir", "", "Directory to write output logs")
+	loginCmd.Flags().BoolVar(&autoRefreshArg, "auto-refresh", false, "Automatically refresh PK token after login")
+	loginCmd.Flags().StringVar(&logDirArg, "log-dir", "", "Directory to write output logs")
 	loginCmd.Flags().BoolVar(&disableBrowserOpenArg, "disable-browser-open", false, "Set this flag to disable opening the browser. Useful for choosing the browser you want to use.")
 	loginCmd.Flags().BoolVar(&printIdTokenArg, "print-id-token", false, "Set this flag to print out the contents of the id_token. Useful for inspecting claims.")
 	loginCmd.Flags().StringVar(&providerArg, "provider", "", "OpenID Provider specification in the format: <issuer>,<client_id> or <issuer>,<client_id>,<client_secret>")

--- a/main.go
+++ b/main.go
@@ -95,6 +95,8 @@ Arguments:
 				inputIssuer = "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0"
 			case "gitlab":
 				inputIssuer = "https://gitlab.com"
+			case "hello":
+				inputIssuer = "https://issuer.hello.coop"
 			}
 
 			add := commands.AddCmd{


### PR DESCRIPTION
This PR:
* adds support for the [hello.dev](https://www.hello.dev/) OpenID Provider as a default OP
* fixes typos in the readme
* improves testing on the login command
* makes login argument names more consistent

Manually tested from windows to ubuntu