### PR TITLE
docs: consistent arguments docs for login provider

### DIFF
--- a/main.go
+++ b/main.go
@@ -133,9 +133,8 @@ Arguments:
 `,
 		Example: `  opkssh login
   opkssh login google
-  opkssh login --provider=<issuer>,<client_id>`,
+  opkssh login --provider=<issuer>,<client_id>,<client_secret>,<scopes>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			sigs := make(chan os.Signal, 1)
@@ -165,7 +164,7 @@ Arguments:
 	loginCmd.Flags().StringVar(&logDir, "log-dir", "", "Directory to write output logs")
 	loginCmd.Flags().BoolVar(&disableBrowserOpenArg, "disable-browser-open", false, "Set this flag to disable opening the browser. Useful for choosing the browser you want to use.")
 	loginCmd.Flags().BoolVar(&printIdTokenArg, "print-id-token", false, "Set this flag to print out the contents of the id_token. Useful for inspecting claims.")
-	loginCmd.Flags().StringVar(&providerArg, "provider", "", "OpenID Provider specification in the format: <issuer>,<client_id> or <issuer>,<client_id>,<client_secret>")
+	loginCmd.Flags().StringVar(&providerArg, "provider", "", "OpenID Provider specification in the format: <issuer>,<client_id> or <issuer>,<client_id>,<client_secret> or <issuer>,<client_id>,<client_secret>,<scopes>")
 	loginCmd.Flags().StringVarP(&keyPathArg, "private-key-file", "i", "", "Path where private keys is written.")
 	rootCmd.AddCommand(loginCmd)
 
@@ -250,7 +249,6 @@ Arguments:
 
 			providerPolicyPath := "/etc/opk/providers"
 			providerPolicy, err := policy.NewProviderFileLoader().LoadProviderPolicy(providerPolicyPath)
-
 			if err != nil {
 				log.Println("Failed to open /etc/opk/providers:", err)
 				return err
@@ -307,7 +305,6 @@ func printConfigProblems() {
 // system running the verifier is greater than or equal to 8.1;
 // if not then prints a warning
 func checkOpenSSHVersion() {
-
 	// Redhat/centos does not recognize `sshd -V` but does recognize `ssh -V`
 	// Ubuntu recognizes both
 	cmd := exec.Command("ssh", "-V")


### PR DESCRIPTION
Just noticed that the provider flag is missing documentation about the newly added scope support.

How do you feel about a terser documentation style, e.g., Linux based: `<issuer>,<client_id>[,<client_secret>[,<scopes>]]` instead of `<issuer>,<client_id> or <issuer>,<client_id>,<client_secret> or <issuer>,<client_id>,<client_secret>,<scopes>`.

Since we are now counting 4 parameters within the single provider argument, would it be worth considering a breaking change and break them out into their own arguments? Something like `--provider-issuer`, `--provider-client-id`, `--provider-client-secret` and `--provider-scopes`. This would leave the implementation more flexible to accomodate future flags.