### PR TITLE
Improve integration test runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         go-version-file: 'go.mod'
     - name: Install Docker
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     - name: Install dependencies
       run: go mod download
     - name: Run integration tests

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ opk-ssh-login
 
 # Build folder
 dist/
+
+# Created by integration tests
+test/integration/testfile.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,22 @@ To run the [Google example](https://github.com/openpubkey/openpubkey/tree/main/e
  3. Execute `./google login` to generate a valid PK token using Google as your OIDC provider.
  4. Execute `./google sign` to use the PK token generated in (3) to sign a verifiable message.
 
+## Integration Tests
+
+To run the integration tests, you need
+[Docker installed](https://docs.docker.com/engine/install/)
+and running, because the integration tests make use of
+[go testcontainers](https://golang.testcontainers.org/).
+
+Then run the integration tests with:
+
+```bash
+# Other supported values are 'centos', 'arch'
+# See test/integrationtest/ssh_server/ssh_server.go for more details
+export OS_TYPE="ubuntu"
+go test -tags=integration ./test/integration -timeout=15m -count=1 -v
+```
+
 ## Building and Packaging `opkssh` Locally
 
 `opkssh` leverages on [GoReleaser](https://goreleaser.com/) to simplify the process of building binaries for all supported systems and architectures, as well as creating distribution packages.

--- a/test/integration/provider/exampleop.Dockerfile
+++ b/test/integration/provider/exampleop.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.12-bookworm
+FROM golang:1.23
 
 ENV AUTH_CALLBACK_PATH ""
 ENV REDIRECT_PORT ""

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -245,7 +245,8 @@ func spawnTestContainers(t *testing.T) (oidcContainer *testprovider.ExampleOpCon
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, oidcContainer.Terminate(TestCtx), "failed to terminate OIDC container")
+		t.Log("Terminating OIDC container")
+		require.NoError(t, oidcContainer.Terminate(TestCtx, testcontainers.StopTimeout(time.Millisecond)), "failed to terminate OIDC container")
 	})
 
 	// Track OIDC server logs and dump if test fails
@@ -273,7 +274,8 @@ func spawnTestContainers(t *testing.T) (oidcContainer *testprovider.ExampleOpCon
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, serverContainer.Terminate(TestCtx), "failed to terminate SSH container")
+		t.Log("Terminating SSH container")
+		require.NoError(t, serverContainer.Terminate(TestCtx, testcontainers.StopTimeout(time.Millisecond)), "failed to terminate SSH container")
 	})
 
 	// Use backdoor (non-OPK) SSH client to dump opkssh logs if test fails


### PR DESCRIPTION
These implement the suggested changes from #149 about
+ force stopping provider image
+ common base image

This brings the execution down to [4m30s](https://github.com/datosh/opkssh/actions/runs/14536212955) from [5m30s](https://github.com/openpubkey/opkssh/actions/runs/14526845268)

It also adds documentation about local execution of integration tests, and upgrades the major version of buildx action to provide more details on execution.