### PR TITLE
Use shellquote for parsing `policy::Table`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jeremija/gosubmit v0.2.7 h1:At0OhGCFGPXyjPYAsCchoBUhE099pcBXmsb4iZqROIc=
 github.com/jeremija/gosubmit v0.2.7/go.mod h1:Ui+HS073lCFREXBbdfrJzMB57OI/bdxTiLtrDHHhFPI=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=

--- a/policy/files/table.go
+++ b/policy/files/table.go
@@ -16,7 +16,12 @@
 
 package files
 
-import "strings"
+import (
+	"log"
+	"strings"
+
+	"github.com/kballard/go-shellquote"
+)
 
 type Table struct {
 	rows [][]string
@@ -30,7 +35,12 @@ func NewTable(content []byte) *Table {
 		if row == "" {
 			continue
 		}
-		columns := strings.Fields(row)
+		columns, err := shellquote.Split(row)
+
+		if err != nil {
+			log.Printf("Unable to parse: %s. (%s), skipping...\n", row, err)
+			continue
+		}
 		table = append(table, columns)
 	}
 	return &Table{rows: table}
@@ -51,7 +61,7 @@ func (t *Table) AddRow(row ...string) {
 func (t Table) ToString() string {
 	var sb strings.Builder
 	for _, row := range t.rows {
-		sb.WriteString(strings.Join(row, " ") + "\n")
+		sb.WriteString(shellquote.Join(row...) + "\n")
 	}
 	return sb.String()
 }

--- a/policy/files/table_test.go
+++ b/policy/files/table_test.go
@@ -25,45 +25,69 @@ import (
 func TestToTable(t *testing.T) {
 
 	tests := []struct {
-		name   string
-		input  string
-		output [][]string
+		name    string
+		input   string
+		output  [][]string
+		reverse string
 	}{
 		{
-			name:   "empty",
-			input:  "",
-			output: [][]string{},
+			name:    "empty",
+			input:   "",
+			output:  [][]string{},
+			reverse: "",
 		},
 		{
-			name:   "multiple empty rows",
-			input:  "\n     \n\n \n",
-			output: [][]string{},
+			name:    "multiple empty rows",
+			input:   "\n     \n\n \n",
+			output:  [][]string{},
+			reverse: "",
 		},
 		{
-			name:   "commented out row",
-			input:  "# this is a comment\n",
-			output: [][]string{},
+			name:    "commented out row",
+			input:   "# this is a comment\n",
+			output:  [][]string{},
+			reverse: "",
 		},
 		{
-			name:   "multiple rows with comment",
-			input:  "1 2 3\n 4 5#comment \n6 7 #comment\n 8",
-			output: [][]string{{"1", "2", "3"}, {"4", "5"}, {"6", "7"}, {"8"}},
+			name:    "field with spaces",
+			input:   "1 \"2 3\" 3\n",
+			output:  [][]string{{"1", "2 3", "3"}},
+			reverse: "1 '2 3' 3\n",
+		},
+		{
+			name:    "field with spaces",
+			input:   "1 'oidc:claims[\"https://example.com/my-custom-groups\"].contains(\"group with space and :\")' 3\n",
+			output:  [][]string{{"1", "oidc:claims[\"https://example.com/my-custom-groups\"].contains(\"group with space and :\")", "3"}},
+			reverse: "1 'oidc:claims[\"https://example.com/my-custom-groups\"].contains(\"group with space and :\")' 3\n",
+		},
+		{
+			name:    "multiple rows with comment",
+			input:   "1 2 3\n 4 5#comment \n6 7 #comment\n 8",
+			output:  [][]string{{"1", "2", "3"}, {"4", "5"}, {"6", "7"}, {"8"}},
+			reverse: "1 2 3\n4 5\n6 7\n8\n",
 		},
 		{
 			name: "realistic input",
-			input: `# Issuer Client-ID expiration-policy
-https://accounts.google.com 206584157355-7cbe4s640tvm7naoludob4ut1emii7sf.apps.googleusercontent.com 24h
-https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0 096ce0a3-5e72-4da8-9c86-12924b294a01 24h`,
+			input: "# Issuer Client-ID expiration-policy\n" +
+				"https://accounts.google.com 206584157355-7cbe4s640tvm7naoludob4ut1emii7sf.apps.googleusercontent.com 24h\n" +
+				"https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0 096ce0a3-5e72-4da8-9c86-12924b294a01 24h",
 			output: [][]string{
 				{"https://accounts.google.com", "206584157355-7cbe4s640tvm7naoludob4ut1emii7sf.apps.googleusercontent.com", "24h"},
 				{"https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0", "096ce0a3-5e72-4da8-9c86-12924b294a01", "24h"},
 			},
+			reverse: "https://accounts.google.com 206584157355-7cbe4s640tvm7naoludob4ut1emii7sf.apps.googleusercontent.com 24h\n" +
+				"https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0 096ce0a3-5e72-4da8-9c86-12924b294a01 24h\n",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			inputBytes := []byte(tt.input)
-			assert.Equal(t, tt.output, NewTable(inputBytes).GetRows())
+			output := NewTable(inputBytes)
+
+			reverse := output.ToString()
+
+			assert.Equal(t, tt.output, output.GetRows())
+			assert.Equal(t, tt.reverse, reverse)
 		})
 	}
 }


### PR DESCRIPTION
This replaces the current approach for parsing policy (space delimited) with `shellquote`. This allows us to include spaces in policy fields.

This is important for:
- policy matching for groups that include spaces
- the future use of CEL
