### PR TITLE
Add client provider commands

### DIFF
--- a/commands/config/client_config.go
+++ b/commands/config/client_config.go
@@ -18,7 +18,12 @@ package config
 
 import (
 	_ "embed"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
 
+	"github.com/spf13/afero"
 	"gopkg.in/yaml.v3"
 )
 
@@ -41,4 +46,67 @@ func NewClientConfig(c []byte) (*ClientConfig, error) {
 
 func (c *ClientConfig) GetProvidersMap() (map[string]ProviderConfig, error) {
 	return CreateProvidersMap(c.Providers)
+}
+
+func GetDefaultClientConfigPath(configPath string) (string, error) {
+	dir, dirErr := os.UserHomeDir()
+	if dirErr != nil {
+		return "", fmt.Errorf("failed to get user config dir: %w", dirErr)
+	}
+	return filepath.Join(dir, ".opk", "config.yml"), nil
+}
+
+// GetClientConfigFromFile is a function to retrieve the client config from the configuration at
+// configPath. If configPath is not specified then the default configuration path is uses ~/.opk/config.yml
+func GetClientConfigFromFile(configPath string, Fs afero.Fs) (*ClientConfig, error) {
+	if configPath == "" {
+		var err error
+		configPath, err = GetDefaultClientConfigPath(configPath)
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var configBytes []byte
+	// Load the file from the filesystem
+	afs := &afero.Afero{Fs: Fs}
+	configBytes, err := afs.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+	config, err := NewClientConfig(configBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+	return config, nil
+}
+
+func CreateDefaultClientConfig(configPath string, Fs afero.Fs) error {
+	if configPath == "" {
+		var err error
+		configPath, err = GetDefaultClientConfigPath(configPath)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	if _, err := Fs.Stat(configPath); err == nil {
+		return fmt.Errorf("attempting to create config file but config file already exists at %s", configPath)
+	}
+
+	afs := &afero.Afero{Fs: Fs}
+
+	if err := afs.Fs.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	if err := afs.WriteFile(configPath, DefaultClientConfig, 0644); err != nil {
+		return fmt.Errorf("failed to write default config file: %w", err)
+	}
+
+	log.Printf("created client config file at %s", configPath)
+
+	return nil
 }

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
         opkssh = pkgs.buildGoModule {
           name = "opkssh";
           src = self;
-          vendorHash = "sha256-6nTRiybsNtP/BiDaNrFEGEGM41BAjGpOyQ0AlQimSE4=";
+          vendorHash = "sha256-8q/jEWZMGeHAOTy3RD7sW9SY3b4QxQ3ZhLtt5Li1hDs=";
           goSum = ./go.sum;
           meta.mainProgram = "opkssh";
         };

--- a/go.mod
+++ b/go.mod
@@ -41,10 +41,12 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jedib0t/go-pretty/v6 v6.6.7 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
+	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/patternmatcher v0.6.0 // indirect
 	github.com/moby/sys/sequential v0.5.0 // indirect
@@ -58,6 +60,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/sftp v1.13.7 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rs/cors v1.11.0 // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rH
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jedib0t/go-pretty/v6 v6.6.7 h1:m+LbHpm0aIAPLzLbMfn8dc3Ht8MW7lsSO4MPItz/Uuo=
+github.com/jedib0t/go-pretty/v6 v6.6.7/go.mod h1:YwC5CE4fJ1HFUDeivSV1r//AmANFHyqczZk+U6BDALU=
 github.com/jeremija/gosubmit v0.2.7 h1:At0OhGCFGPXyjPYAsCchoBUhE099pcBXmsb4iZqROIc=
 github.com/jeremija/gosubmit v0.2.7/go.mod h1:Ui+HS073lCFREXBbdfrJzMB57OI/bdxTiLtrDHHhFPI=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
@@ -103,6 +105,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
+github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
+github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/melbahja/goph v1.4.0 h1:z0PgDbBFe66lRYl3v5dGb9aFgPy0kotuQ37QOwSQFqs=
 github.com/melbahja/goph v1.4.0/go.mod h1:uG+VfK2Dlhk+O32zFrRlc3kYKTlV6+BtvPWd/kK7U68=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
@@ -138,6 +142,9 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
 github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/rs/cors v1.11.0 h1:0B9GE/r9Bc2UxRMMtymBkHTenPkHDv0CW4Y98GBY+po=

--- a/main.go
+++ b/main.go
@@ -302,14 +302,14 @@ Arguments:
 	providerCmd := &cobra.Command{
 		Use:     "provider [subcommand]",
 		Short:   "Interact with provider configuration",
-		Example: `  opkssh provider list`,
+		Example: `  opkssh client provider list`,
 		Args:    cobra.ExactArgs(0),
 	}
 
 	providerListCmd := &cobra.Command{
 		Use:     "list",
 		Short:   "List configured providers",
-		Example: `  opkssh provider list`,
+		Example: `  opkssh client provider list`,
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client_config, err := config.GetClientConfigFromFile(configPathArg, afero.NewOsFs())
@@ -342,10 +342,12 @@ Arguments:
 
 	providerCmd.AddCommand(providerListCmd)
 
-	providerInitCmd := &cobra.Command{
-		Use:     "init",
+	clientCmd.AddCommand(providerCmd)
+
+	initConfigCmd := &cobra.Command{
+		Use:     "init-config",
 		Short:   "Initialize client provider configuration",
-		Example: `  opkssh provider init`,
+		Example: `  opkssh client init-config`,
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := config.CreateDefaultClientConfig(configPathArg, afero.NewOsFs())
@@ -357,11 +359,9 @@ Arguments:
 		},
 	}
 
-	providerInitCmd.Flags().StringVar(&configPathArg, "config-path", "", "Path to the client config file. Default: ~/.opk/config.yml on linux and %APPDATA%\\.opk\\config.yml on windows.")
+	initConfigCmd.Flags().StringVar(&configPathArg, "config-path", "", "Path to the client config file. Default: ~/.opk/config.yml on linux and %APPDATA%\\.opk\\config.yml on windows.")
 
-	providerCmd.AddCommand(providerInitCmd)
-
-	clientCmd.AddCommand(providerCmd)
+	clientCmd.AddCommand(initConfigCmd)
 
 	rootCmd.AddCommand(clientCmd)
 


### PR DESCRIPTION
Closes #160 

## What
* Add `client` subcommand to root command
* Add `provider` subcommand to `client` command
* Add `list` subcommand to `provider` subcommand
* Add `init` subcommand to `provider` subcommand
* Add [go-pretty](https://pkg.go.dev/github.com/jedib0t/go-pretty/v6/table) package

## Why
As a user it is nice to see what providers are available and their aliases

It means I can do something like:

```bash
opkssh client provider list
```

```bash
+-----------+-----------------------------------------------------------------------------+
| PROVIDERS | ISSUER                                                                      |
+-----------+-----------------------------------------------------------------------------+
| gitlab    | https://gitlab.com                                                          |
| hello     | https://issuer.hello.coop                                                   |
| google    | https://accounts.google.com                                                 |
| azure     | https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0 |
| microsoft | https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0 |
+-----------+-----------------------------------------------------------------------------+
```
```bash
opkssh login google
```

I also would like an intuitive way to initialize the default client configuration.

```bash
opkssh client provider init
```
```bash
2025/05/13 21:20:10 created client config file at /home/johndoe/.opk/config.yml
```