### PR TITLE
Document configuration for Gitlab selfhosted

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,10 +448,10 @@ opkssh add root alice@example.com https://authentik.local/application/o/opkssh/
 |-------------------------------------------|--------|-------------------------------------------------------------------------------------------------------------|
 | [Authelia](https://www.authelia.com/)     | ✅      | [Authelia Integration Guide](https://www.authelia.com/integration/openid-connect/opkssh/)                   |
 | [Authentik](https://goauthentik.io/)      | ✅      | Do not add a certificate in the encryption section of the provider                                          |
+| [Gitlab Self-hosted](https://gitlab.com/) | ✅      | [Configuration guide](docs/gitlab-selfhosted.md)                                                            |
 | [Kanidm](https://kanidm.com/)             | ✅      | [Kanidm Integration Guide](https://kanidm.github.io/kanidm/master/integrations/oauth2/examples.html#opkssh) |
 | [PocketID](https://pocket-id.org/)        | ✅      | Create a new OIDC Client and inside the new client, check "Public client" on OIDC Client Settings           |
 | [Zitadel](https://zitadel.com/)           | ✅      | Check the UserInfo box on the Token Settings                                                                |
-| [Gitlab Self-hosted](https://gitlab.com/) | ✅      | [Configuration guide](docs/gitlab-selfhosted.md)                                                            |
 
 Do not use Confidential/Secret mode **only** client ID is needed.
 

--- a/README.md
+++ b/README.md
@@ -444,13 +444,14 @@ opkssh add root alice@example.com https://authentik.local/application/o/opkssh/
 
 ### Tested
 
-| OpenID Provider                       | Tested | Notes                                                                                                       |
-| ------------------------------------- | ------ | ----------------------------------------------------------------------------------------------------------- |
-| [Authelia](https://www.authelia.com/) | ✅     | [Authelia Integration Guide](https://www.authelia.com/integration/openid-connect/opkssh/)                   |
-| [Authentik](https://goauthentik.io/)  | ✅     | Do not add a certificate in the encryption section of the provider                                          |
-| [Kanidm](https://kanidm.com/)         | ✅     | [Kanidm Integration Guide](https://kanidm.github.io/kanidm/master/integrations/oauth2/examples.html#opkssh) |
-| [PocketID](https://pocket-id.org/)    | ✅     | Create a new OIDC Client and inside the new client, check "Public client" on OIDC Client Settings           |
-| [Zitadel](https://zitadel.com/)       | ✅     | Check the UserInfo box on the Token Settings                                                                |
+| OpenID Provider                           | Tested | Notes                                                                                                       |
+|-------------------------------------------|--------|-------------------------------------------------------------------------------------------------------------|
+| [Authelia](https://www.authelia.com/)     | ✅      | [Authelia Integration Guide](https://www.authelia.com/integration/openid-connect/opkssh/)                   |
+| [Authentik](https://goauthentik.io/)      | ✅      | Do not add a certificate in the encryption section of the provider                                          |
+| [Kanidm](https://kanidm.com/)             | ✅      | [Kanidm Integration Guide](https://kanidm.github.io/kanidm/master/integrations/oauth2/examples.html#opkssh) |
+| [PocketID](https://pocket-id.org/)        | ✅      | Create a new OIDC Client and inside the new client, check "Public client" on OIDC Client Settings           |
+| [Zitadel](https://zitadel.com/)           | ✅      | Check the UserInfo box on the Token Settings                                                                |
+| [Gitlab Self-hosted](https://gitlab.com/) | ✅      | [Configuration guide](docs/gitlab-selfhosted.md)                                                            |
 
 Do not use Confidential/Secret mode **only** client ID is needed.
 

--- a/docs/gitlab-selfhosted.md
+++ b/docs/gitlab-selfhosted.md
@@ -1,0 +1,57 @@
+# Configure Self hosted Gitlab instance
+
+### Create an OAuth Application in Gitlab
+
+Create an OAuth application in your Gitlab instance that allows opkssh access.
+
+1. Go to the Gitlab Admin page
+2. Go to Applications, add a new application
+3. Give it a descriptive name (Users will see this name when they authorize opkssh)
+4. For the redirect URI's enter:
+    ```
+    http://localhost:3000/login-callback
+    http://localhost:10001/login-callback
+    http://localhost:11110/login-callback 
+    ```
+5. Deselect Trusted and Confidential.
+6. Select the scopes: `openid`, `profile` and `email`
+
+Create the application and note the Application ID.
+
+### Configure the client
+
+Add the configuration in the [config file](../README.md#client-config-file)
+
+```
+providers:
+  - alias: my-gitlab
+    issuer: https://my-gitlab-url.com
+    client_id: <Application ID>
+    scopes: openid email
+    access_type: offline
+    prompt: consent
+    redirect_uris:
+      - http://localhost:3000/login-callback
+      - http://localhost:10001/login-callback
+      - http://localhost:11110/login-callback
+```
+
+You can then log in using your Gitlab instance via
+
+```
+opkssh login my-gitlab
+```
+
+### Configure the server
+
+Add the Gitlab URL and Application ID to the [providers file](../README.md#etcopkproviders) on the server:
+
+```
+https://my-gitlab-url.com <Application ID> 24h
+```
+
+Then add identities to the policy to allow those identities to SSH to the server:
+
+```
+opkssh add root alice@example.com https://my-gitlab-url.com
+```


### PR DESCRIPTION
While setting it up was mostly self explanatory, I did need to try some different settings in the Gitlab application before it worked, so I decided to add  some documentation to make it easier for others.