### PR TITLE
Add Nix Flake to build opkssh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,16 @@ jobs:
       run: go mod download
     - name: Build
       run: go build -v -o /dev/null
+  nix-build:
+    name: Nix Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Build
+        run: nix build .
   # Run integration tests
   test:
     needs: build

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1746422338,
+        "narHash": "sha256-NTtKOTLQv6dPfRe00OGSywg37A1FYqldS6xiNmqBUYc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5b35d248e9206c1f3baf8de6a7683fee126364aa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+
+{
+  description = "Open Pubkey for SSH";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-24.11";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supported-systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      # Helper to provide system-specific attributes
+      forSupportedSystems = f: nixpkgs.lib.genAttrs supported-systems (system: f {
+        pkgs = import nixpkgs { inherit system; };
+      });
+    in
+    {
+      packages = forSupportedSystems ({ pkgs }: rec {
+        opkssh = pkgs.buildGoModule {
+          name = "opkssh";
+          src = self;
+          vendorHash = "sha256-6nTRiybsNtP/BiDaNrFEGEGM41BAjGpOyQ0AlQimSE4=";
+          goSum = ./go.sum;
+        };
+        default = opkssh;
+      });
+    };
+}


### PR DESCRIPTION
Add a simple Nix flake that defines a package.  This makes it easy to build `opkssh` in a reproducible way via the `nix build` command.

If you have flakes enabled, you can try the following command to build `opkssh` from my branch:
```sh
nix build github:javbit/opkssh/nix-flake
```