### PR TITLE
GHA based login

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -1,0 +1,65 @@
+name: Test GitHub Provider
+
+on:
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    timeout-minutes: 5
+    steps:
+    - name: Checkout
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      with:
+        persist-credentials: false
+    - name: Install Go
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+      with:
+        go-version-file: 'go.mod'
+    - name: Install dependencies
+      run: go mod download
+    - name: Build
+      run: go build -v -o /dev/null
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
+    - name: Build and export to Docker
+      uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6
+      with:
+        build-args: |
+          AUTHORIZED_REPOSITORY=${{ github.repository }}
+          AUTHORIZED_REF=${{ github.ref }}
+        load: true
+        tags: sshserver:latest
+        file: .github/workflows/gha_opkssh.Dockerfile
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Run SSH Container
+      run: docker run -d -p 2222:22 sshserver:latest
+
+    - name: Login
+      run: go run main.go login github --print-id-token
+
+    - name: SSH into Container with opkssh
+      run: |
+        ssh -o StrictHostKeyChecking=no -p 2222 test@localhost ls -la
+
+    - name: Debug - dump opkssh config
+      run: |
+        sshpass -p test ssh -o StrictHostKeyChecking=no -p 2222 test@localhost ls -la /etc/opk || true
+        sshpass -p test ssh -o StrictHostKeyChecking=no -p 2222 test@localhost sudo cat /etc/opk/providers || true
+        sshpass -p test ssh -o StrictHostKeyChecking=no -p 2222 test@localhost sudo cat /etc/opk/auth_id || true
+      if: always()
+
+    - name: Debug - dump logs
+      run: |
+        sshpass -p test ssh -o StrictHostKeyChecking=no -p 2222 test@localhost sudo cat /var/log/opkssh.log
+      if: always()

--- a/commands/config/default-client-config.yml
+++ b/commands/config/default-client-config.yml
@@ -46,4 +46,3 @@ providers:
       - http://localhost:3000/login-callback
       - http://localhost:10001/login-callback
       - http://localhost:11110/login-callback
-

--- a/commands/login.go
+++ b/commands/login.go
@@ -27,7 +27,6 @@ import (
 	"io"
 	"log"
 	"os"
-
 	"path/filepath"
 	"strings"
 	"time"
@@ -151,6 +150,8 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 			return fmt.Errorf("failed to parse default config file: %w", err)
 		}
 	}
+
+	l.config.Providers = append(l.config.Providers, config.GitHubProviderConfig())
 
 	var provider providers.OpenIdProvider
 	if l.overrideProvider != nil {
@@ -311,7 +312,6 @@ func (l *LoginCmd) login(ctx context.Context, provider providers.OpenIdProvider,
 
 	if printIdToken {
 		idTokenStr, err := PrettyIdToken(*pkt)
-
 		if err != nil {
 			return nil, fmt.Errorf("failed to format ID Token: %w", err)
 		}
@@ -535,7 +535,6 @@ func PrettyIdToken(pkt pktoken.PKToken) (string, error) {
 		return "", err
 	}
 	idtJson, err := json.MarshalIndent(idt.GetClaims(), "", "    ")
-
 	if err != nil {
 		return "", err
 	}

--- a/policy/providerloader.go
+++ b/policy/providerloader.go
@@ -89,6 +89,8 @@ func (p *ProviderPolicy) CreateVerifier() (*verifier.Verifier, error) {
 			opts.Issuer = row.Issuer
 			opts.ClientID = row.ClientID
 			provider = providers.NewGitlabOpWithOptions(opts)
+		} else if row.Issuer == "https://token.actions.githubusercontent.com" {
+			provider = providers.NewGithubOp(row.Issuer, "")
 		} else {
 			opts := providers.GetDefaultGoogleOpOptions()
 			opts.Issuer = row.Issuer
@@ -183,7 +185,7 @@ func (o *ProvidersFileLoader) FromTable(input []byte, path string) *ProviderPoli
 		policyRow := ProvidersRow{
 			Issuer:           row[0],
 			ClientID:         row[1],
-			ExpirationPolicy: row[2], //TODO: Validate this so that we can determine the line number that has the error
+			ExpirationPolicy: row[2], // TODO: Validate this so that we can determine the line number that has the error
 		}
 		policy.AddRow(policyRow)
 	}


### PR DESCRIPTION
This is a very first draft to make progress towards #53 

The current proof of concept helped me to understand what code paths are required to make GHA support happen, and where we would require some refactoring of the current opkssh implementation.

I was able to put together a full end-2-end test for GitHub Actions based provider, implemented via `gha.yml`.
To achieve this I have pirated the `debian_opkssh.Dockerfile` from the integration tests :wink: A full pipeline run is available in [my fork](https://github.com/datosh/opkssh/actions/runs/14915506741) and in particular  [login](https://github.com/datosh/opkssh/actions/runs/14915506741/job/41899991125#step:9:1) &  [ssh via opkssh](https://github.com/datosh/opkssh/actions/runs/14915506741/job/41899991125#step:11:1)

Limitations I have identified so far:
+ **Adding GitHub Actions to the `*config.ClientConfig` to handle `opkssh login`**: The way I added GitHub as a provider to the default configuration doesn't feel right. I had to put a dummy client ID, because the field is required, in addition, no one would ever need this config to exist. Most CI runner are ephemeral, so there is no need to persist it.
I would instead suggest to always add GitHub Actions (and other CI environments) to the `config` field after the default or user config is loaded.
* The extension to `policy/providerloader.go`  feels wrong. I cannot use the `NewGithubOpFromEnvironment` function, as the verifier does not run inside GHA, at the same time `NewGithubOp` requires me to pass the `token`. As far as I understand openpubkey verification, I need to create a provider to generate a verifier from it..? Sadly I was not able to find an example for GHA based verification, only https://github.com/openpubkey/openpubkey/pull/117/files which is a year old and it's kinda cheating by creating the provider and verifier from it in the same code block.

Happy for any comments on direction for this implementation! 