### PR TITLE
Sets permissions for directories we create on install

### DIFF
--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -257,20 +257,36 @@ echo "Installed $BINARY_NAME to $INSTALL_DIR/$BINARY_NAME"
 if command -v $INSTALL_DIR/$BINARY_NAME &> /dev/null; then
     # Setup configuration
     echo "Configuring opkssh:"
-    mkdir -p /etc/opk
-    mkdir -p /etc/opk/policy.d
 
-    touch /etc/opk/auth_id
-    chown root:${AUTH_CMD_GROUP} /etc/opk/auth_id
-    chmod 640 /etc/opk/auth_id
+    if [ ! -e "/etc/opk" ]; then
+        mkdir -p /etc/opk
+        chown root:${AUTH_CMD_GROUP} /etc/opk
+        chmod 751 /etc/opk
+    fi
 
-    touch /etc/opk/config.yml
-    chown root:${AUTH_CMD_GROUP} /etc/opk/config.yml
-    chmod 640 /etc/opk/config.yml
+    if [ ! -e "/etc/opk/policy.d" ]; then
+        mkdir -p /etc/opk/policy.d
+        chown root:${AUTH_CMD_GROUP} /etc/opk/policy.d
+        chmod 751 /etc/opk/policy.d
+    fi
 
-    touch /etc/opk/providers
-    chown root:${AUTH_CMD_GROUP} /etc/opk/providers
-    chmod 640 /etc/opk/providers
+    if [ ! -e "/etc/opk/auth_id" ]; then
+        touch /etc/opk/auth_id
+        chown root:${AUTH_CMD_GROUP} /etc/opk/auth_id
+        chmod 640 /etc/opk/auth_id
+    fi
+
+    if [ ! -e "/etc/opk/config.yml" ]; then
+        touch /etc/opk/config.yml
+        chown root:${AUTH_CMD_GROUP} /etc/opk/config.yml
+        chmod 640 /etc/opk/config.yml
+    fi
+
+    if [ ! -e "/etc/opk/providers" ]; then
+        touch /etc/opk/providers
+        chown root:${AUTH_CMD_GROUP} /etc/opk/providers
+        chmod 640 /etc/opk/providers
+    fi
 
     if [ -s /etc/opk/providers ]; then
         echo "  The providers policy file (/etc/opk/providers) is not empty. Keeping existing values"

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -261,13 +261,13 @@ if command -v $INSTALL_DIR/$BINARY_NAME &> /dev/null; then
     if [ ! -e "/etc/opk" ]; then
         mkdir -p /etc/opk
         chown root:${AUTH_CMD_GROUP} /etc/opk
-        chmod 751 /etc/opk
+        chmod 750 /etc/opk
     fi
 
     if [ ! -e "/etc/opk/policy.d" ]; then
         mkdir -p /etc/opk/policy.d
         chown root:${AUTH_CMD_GROUP} /etc/opk/policy.d
-        chmod 751 /etc/opk/policy.d
+        chmod 750 /etc/opk/policy.d
     fi
 
     if [ ! -e "/etc/opk/auth_id" ]; then


### PR DESCRIPTION
Inspired by https://github.com/openpubkey/opkssh/issues/191 where a user ran into an issue because the created directories didn't have the correct permissions