### PR TITLE
fix: read send_access_token when parsing config

### DIFF
--- a/commands/config/client_config_test.go
+++ b/commands/config/client_config_test.go
@@ -51,5 +51,28 @@ func TestParseConfig(t *testing.T) {
 	clientConfigDefault, err = NewClientConfig([]byte("invalid yaml"))
 	require.ErrorContains(t, err, "yaml: unmarshal errors")
 	require.Nil(t, clientConfigDefault)
+}
 
+func TestParseConfigWithSendAccessToken(t *testing.T) {
+	c := `---
+default_provider: webchooser
+
+providers:
+  - alias: google
+    issuer: https://accounts.google.com
+    client_id: 206584157355-7cbe4s640tvm7naoludob4ut1emii7sf.apps.googleusercontent.com
+    client_secret: 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
+    scopes: openid email profile
+    access_type: offline
+    send_access_token: true
+    prompt: consent
+    redirect_uris:
+      - http://localhost:3000/login-callback
+      - http://localhost:10001/login-callback
+      - http://localhost:11110/login-callback`
+
+	clientConfig, err := NewClientConfig([]byte(c))
+	require.NoError(t, err)
+	require.NotNil(t, clientConfig)
+	require.Equal(t, clientConfig.Providers[0].SendAccessToken, true)
 }

--- a/commands/config/providerconfig.go
+++ b/commands/config/providerconfig.go
@@ -45,14 +45,15 @@ type ProviderConfig struct {
 
 func (p *ProviderConfig) UnmarshalYAML(value *yaml.Node) error {
 	var tmp struct {
-		AliasList    string   `yaml:"alias"`
-		Issuer       string   `yaml:"issuer"`
-		ClientID     string   `yaml:"client_id"`
-		ClientSecret string   `yaml:"client_secret"`
-		Scopes       string   `yaml:"scopes"`
-		AccessType   string   `yaml:"access_type"`
-		Prompt       string   `yaml:"prompt"`
-		RedirectURIs []string `yaml:"redirect_uris"`
+		AliasList       string   `yaml:"alias"`
+		Issuer          string   `yaml:"issuer"`
+		ClientID        string   `yaml:"client_id"`
+		ClientSecret    string   `yaml:"client_secret"`
+		Scopes          string   `yaml:"scopes"`
+		AccessType      string   `yaml:"access_type"`
+		Prompt          string   `yaml:"prompt"`
+		RedirectURIs    []string `yaml:"redirect_uris"`
+		SendAccessToken bool     `yaml:"send_access_token,omitempty"`
 	}
 
 	// Set default values
@@ -69,14 +70,15 @@ func (p *ProviderConfig) UnmarshalYAML(value *yaml.Node) error {
 		return err
 	}
 	*p = ProviderConfig{
-		AliasList:    strings.Fields(tmp.AliasList),
-		Issuer:       tmp.Issuer,
-		ClientID:     tmp.ClientID,
-		ClientSecret: tmp.ClientSecret,
-		Scopes:       strings.Fields(tmp.Scopes),
-		AccessType:   tmp.AccessType,
-		Prompt:       tmp.Prompt,
-		RedirectURIs: tmp.RedirectURIs,
+		AliasList:       strings.Fields(tmp.AliasList),
+		Issuer:          tmp.Issuer,
+		ClientID:        tmp.ClientID,
+		ClientSecret:    tmp.ClientSecret,
+		Scopes:          strings.Fields(tmp.Scopes),
+		AccessType:      tmp.AccessType,
+		Prompt:          tmp.Prompt,
+		RedirectURIs:    tmp.RedirectURIs,
+		SendAccessToken: tmp.SendAccessToken,
 	}
 	return nil
 }


### PR DESCRIPTION
Fixed a bug where the new config field `send_access_token` was not parsed from yaml config file.