### PR TITLE
Write the certificate where OpenSSH will find it

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ opkssh login -i opkssh_server_group1
 Tell ssh to use the generated key pair.
 
 ```bash
-ssh -o "IdentitiesOnly=yes" -i ~/.ssh/opkssh_server_group1.pub -i ~/.ssh/opkssh_server_group1 root@example.com
+ssh -o "IdentitiesOnly=yes" -i ~/.ssh/opkssh_server_group1 root@example.com
 ```
 
 We recommend specifying `-o "IdentitiesOnly=yes"` as it tells ssh to only use the provided key. Otherwise ssh will cycle through other keys in `~/.ssh` first and may not get to the specified ones. Servers are configured to only allow 6 attempts by default the config key is `MaxAuthTries 6`.

--- a/commands/login.go
+++ b/commands/login.go
@@ -327,7 +327,7 @@ func (l *LoginCmd) login(ctx context.Context, provider providers.OpenIdProvider,
 	// Write ssh secret key and public key to filesystem
 	if seckeyPath != "" {
 		// If we have set seckeyPath then write it there
-		if err := l.writeKeys(seckeyPath, seckeyPath+".pub", seckeySshPem, certBytes); err != nil {
+		if err := l.writeKeys(seckeyPath, seckeyPath+"-cert.pub", seckeySshPem, certBytes); err != nil {
 			return nil, fmt.Errorf("failed to write SSH keys to filesystem: %w", err)
 		}
 	} else {
@@ -418,7 +418,7 @@ func (l *LoginCmd) LoginWithRefresh(ctx context.Context, provider providers.Refr
 			// Write ssh secret key and public key to filesystem
 			if seckeyPath != "" {
 				// If we have set seckeyPath then write it there
-				if err := l.writeKeys(seckeyPath, seckeyPath+".pub", seckeySshPem, certBytes); err != nil {
+				if err := l.writeKeys(seckeyPath, seckeyPath+"-cert.pub", seckeySshPem, certBytes); err != nil {
 					return fmt.Errorf("failed to write SSH keys to filesystem: %w", err)
 				}
 			} else {
@@ -503,7 +503,7 @@ func (l *LoginCmd) writeKeysToSSHDir(seckeySshPem []byte, certBytes []byte) erro
 	// with a new key.
 	for _, keyFilename := range []string{"id_ecdsa", "id_ed25519"} {
 		seckeyPath := filepath.Join(sshPath, keyFilename)
-		pubkeyPath := seckeyPath + ".pub"
+		pubkeyPath := seckeyPath + "-cert.pub"
 
 		if !l.fileExists(seckeyPath) {
 			// If ssh key file does not currently exist, we don't have to worry about overwriting it

--- a/commands/login_test.go
+++ b/commands/login_test.go
@@ -201,7 +201,7 @@ func TestLoginCmd(t *testing.T) {
 				require.NotNil(t, logBytes)
 				require.Contains(t, string(logBytes), "running login command with args:")
 
-				sshPubPath := filepath.Join(homePath, ".ssh", "id_ecdsa.pub")
+				sshPubPath := filepath.Join(homePath, ".ssh", "id_ecdsa-cert.pub")
 				pubKeyBytes, err := afero.ReadFile(mockFs, sshPubPath)
 				require.NoError(t, err)
 

--- a/docs/paramiko.md
+++ b/docs/paramiko.md
@@ -6,7 +6,7 @@ If you use the `paramiko` libary for Python, then you'll have to manually load t
 import paramiko
 
 private_key = paramiko.ECDSAKey(filename='/home/username/.ssh/opkssh_server_group1')
-private_key.load_certificate('/home/username/.ssh/opkssh_server_group1.pub')
+private_key.load_certificate('/home/username/.ssh/opkssh_server_group1-cert.pub')
 
 sshcon  = paramiko.SSHClient()
 sshcon.set_missing_host_key_policy(paramiko.AutoAddPolicy())

--- a/docs/putty.md
+++ b/docs/putty.md
@@ -32,7 +32,7 @@ In the following steps we provide a walkthrough on how to import the regular SSH
 Generate your OPKSSH ssh key by running `opkssh.exe login`.
 The output of this command will tell you the location opkssh wrote the key on your machine. Make note of this, we will need it in the next step. Typically these files are written to:
 
-- `C:\Users\{USERNAME}\.ssh\id_ecdsa.pub` for the SSH certificate
+- `C:\Users\{USERNAME}\.ssh\id_ecdsa-cert.pub` for the SSH certificate
 - `C:\Users\{USERNAME}\.ssh\id_ecdsa` for the SSH private key
 
 ![Shows terminal output of running opkssh and location of ssh public key and ssh private key](https://github.com/user-attachments/assets/c1101d5e-8e6a-4a7e-82c8-d139b911efb6)

--- a/test/integration/integration.go
+++ b/test/integration/integration.go
@@ -130,8 +130,8 @@ func GetOPKSshKey(seckeyPath string) (ssh.PublicKey, string, error) {
 	for _, secKeyFilePath = range expectedSSHSecKeyFilePaths {
 		secKeyFilePath = filepath.Join(sshPath, secKeyFilePath)
 
-		// Read public key. Expected public key has suffix ".pub"
-		pubKeyFilePath := secKeyFilePath + ".pub"
+		// Read public key. Expected public key has suffix "-cert.pub"
+		pubKeyFilePath := secKeyFilePath + "-cert.pub"
 		sshPubKey, err := os.ReadFile(pubKeyFilePath)
 		if err != nil {
 			continue

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -718,7 +718,7 @@ func TestEndToEndSSHWithRefresh(t *testing.T) {
 	// directory path so we're not touching the host machine's SSH keys
 	err = os.Remove(secKeyFilePath)
 	require.NoError(t, err, "failed to remove OPK SSH private key")
-	err = os.Remove(secKeyFilePath + ".pub")
+	err = os.Remove(secKeyFilePath + "-cert.pub")
 	require.NoError(t, err, "failed to remove OPK SSH public key")
 
 	// Let refresh go through


### PR DESCRIPTION
If given the filename of a private key, and no certificates have been specified, OpenSSH will append "-cert.pub" and try to load certificate data from there. (Cf. ssh(1) man page)