### PR TITLE
Update linter to v2.0.2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v6
         with:
-          version: v1.64.7
+          version: v2.0.2
 
   gotest:
     name: Run Tests


### PR DESCRIPTION
Solves error:
```
Error: Failed to run: Error: invalid version string 'v1.64.7', golangci-lint v1 is not supported by golangci-lint-action >= v7., Error: invalid version string 'v1.64.7', golangci-lint v1 is not supported by golangci-lint-action >= v7.
```