### PR TITLE
Migrate golangcilint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,16 +1,24 @@
+version: "2"
 linters:
   enable:
-  # golangci-lint defaults 
-  # ref: https://golangci-lint.run/usage/linters/#enabled-by-default
-  - errcheck
-  - gosimple
-  - govet
-  - ineffassign
-  - staticcheck
-  - unused
-  # additional
-  - misspell
-  - gofmt
-  fast: true
-run:
-  timeout: 5m
+    - misspell
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/commands/login.go
+++ b/commands/login.go
@@ -585,6 +585,6 @@ func isGitHubEnvironment() bool {
 // payloadFromCompactPkt extracts the payload from a compact PK Token which
 // is always the second part of the '.' separated string.
 func payloadFromCompactPkt(compactPkt []byte) []byte {
-	parts := bytes.SplitN(compactPkt, []byte("."), -1)
+	parts := bytes.Split(compactPkt, []byte("."))
 	return parts[1]
 }

--- a/commands/login_test.go
+++ b/commands/login_test.go
@@ -322,7 +322,7 @@ func TestDetermineProvider(t *testing.T) {
 			} else {
 				require.NoError(t, err, "Unexpected error")
 				require.True(t, provider != nil || chooser != nil, "Provider or chooser should never both be nil")
-				require.True(t, !(provider != nil && chooser != nil), "Provider or chooser should never both be non-nil")
+				require.False(t, provider != nil && chooser != nil, "Provider or chooser should never both be non-nil")
 
 				if tt.wantIssuer != "" {
 					require.NotNil(t, provider)

--- a/policy/plugins/plugins_test.go
+++ b/policy/plugins/plugins_test.go
@@ -151,7 +151,7 @@ func TestPolicyPluginsWithMock(t *testing.T) {
 		sub, _ := os.LookupEnv("OPKSSH_PLUGIN_SUB")
 		aud, _ := os.LookupEnv("OPKSSH_PLUGIN_AUD")
 
-		if "/usr/bin/local/opk/policy-cmd" == name {
+		if name == "/usr/bin/local/opk/policy-cmd" {
 
 			if len(arg) != 3 {
 				return nil, fmt.Errorf("expected 3 arguments, got %d", len(arg))

--- a/policy/providerloader.go
+++ b/policy/providerloader.go
@@ -145,7 +145,7 @@ func NewProviderFileLoader() *ProvidersFileLoader {
 }
 
 func (o *ProvidersFileLoader) LoadProviderPolicy(path string) (*ProviderPolicy, error) {
-	content, err := o.FileLoader.LoadFileAtPath(path)
+	content, err := o.LoadFileAtPath(path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Migrated golangci-lint to version 2 as we were already using version 2.x of golangci-lint, to fix pipeline in #122 

I migrated the configuration file using the tool assissted approach [as per documentation](https://golangci-lint.run/product/migration-guide/#command-migrate). This leads to some changes, most relevant for us "`run.timeout`: the existing value is ignored because, in v2, there is no timeout by default.". I would say we accept this for now, and if the action takes too long we add a timeout there.

There have also been changes to the used linters (even though I followed their docs). gosimple for example [was available in v1](https://golangci.github.io/legacy-v1-doc/usage/linters/) but [vanished in v2](https://golangci-lint.run/usage/linters/). 

Do you have strong feelings about the included linters @EthanHeilman ? 
Happy to add more in this PR or create an issue to look into this. 