### PR TITLE
fix: silence error when plugin policy dir missing

### DIFF
--- a/policy/enforcer.go
+++ b/policy/enforcer.go
@@ -18,8 +18,10 @@ package policy
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/openpubkey/openpubkey/pktoken"
@@ -39,6 +41,9 @@ type checkedClaims struct {
 	Sub    string   `json:"sub"`
 	Groups []string `json:"groups"`
 }
+
+// The default location for policy polugins
+const pluginPolicyDir = "/etc/opk/policy.d"
 
 // Validates that the server defined identity attribute matches the
 // respective claim from the identity token
@@ -65,9 +70,13 @@ func validateClaim(claims *checkedClaims, user *User) bool {
 func (p *Enforcer) CheckPolicy(principalDesired string, pkt *pktoken.PKToken, userInfoJson string, sshCert string, keyType string) error {
 	pluginPolicy := plugins.NewPolicyPluginEnforcer()
 
-	results, err := pluginPolicy.CheckPolicies("/etc/opk/policy.d", pkt, userInfoJson, principalDesired, sshCert, keyType)
+	results, err := pluginPolicy.CheckPolicies(pluginPolicyDir, pkt, userInfoJson, principalDesired, sshCert, keyType)
 	if err != nil {
-		log.Printf("Error checking policy plugins: %v \n", err)
+		if errors.Is(err, os.ErrNotExist) {
+			log.Println("Skipping policy plugins: no plugins found at " + pluginPolicyDir)
+		} else {
+			log.Printf("Error checking policy plugins: %v \n", err)
+		}
 		// Despite the error, we don't fail here because we still want to check
 		// the standard policy below. Policy plugins can only expand the set of
 		// allow set, not shrink it.

--- a/policy/enforcer.go
+++ b/policy/enforcer.go
@@ -42,7 +42,7 @@ type checkedClaims struct {
 	Groups []string `json:"groups"`
 }
 
-// The default location for policy polugins
+// The default location for policy plugins
 const pluginPolicyDir = "/etc/opk/policy.d"
 
 // Validates that the server defined identity attribute matches the

--- a/policy/plugins/plugins_test.go
+++ b/policy/plugins/plugins_test.go
@@ -40,6 +40,23 @@ type mockFile struct {
 	Content    string
 }
 
+func TestLoadPolicyPluginsMissing(t *testing.T) {
+	mockFs := afero.NewMemMapFs()
+	enforcer := &PolicyPluginEnforcer{
+		Fs: mockFs,
+		permChecker: files.PermsChecker{
+			Fs: mockFs,
+			CmdRunner: func(name string, arg ...string) ([]byte, error) {
+				return []byte("root" + " " + "group"), nil
+			},
+		},
+	}
+
+	// Load policy commands
+	_, err := enforcer.loadPlugins("/should/not/exist")
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
 func TestLoadPolicyPlugins(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION
The policy plugin directory, i.e. “/etc/opk/policy.d”, is optional. If the directory is missing, do not print an error, print a more friendly message that conveys the missing directory.

Close #212