### PR TITLE
Fix bug in install script

### DIFF
--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -784,8 +784,8 @@ main() {
     log_opkssh_installation
 }
 
-# Only run main if this file is executed, not sourced (like during testing)
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+# Don't run main during testing (SH unit tests source this script)
+if [[ -z "$SHUNIT_RUNNING" ]]; then
     main "$@"
     exit $?
 fi

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -25,7 +25,7 @@
 # ==============================================================================
 #
 
-if [[ "$SHUNIT_RUNNIN" != "1" ]]; then
+if [[ "$SHUNIT_RUNNING" != "1" ]]; then
     # Exit if any command fails, unless running tests
     set -e
 fi

--- a/scripts/test/install-linux_test_check_bash_version.sh
+++ b/scripts/test/install-linux_test_check_bash_version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export SHUNIT_RUNNIN=1
+export SHUNIT_RUNNING=1
 
 
 # Source install-linux.sh

--- a/scripts/test/install-linux_test_check_cpu_architecture.sh
+++ b/scripts/test/install-linux_test_check_cpu_architecture.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export SHUNIT_RUNNIN=1
+export SHUNIT_RUNNING=1
 
 
 # Source install-linux.sh

--- a/scripts/test/install-linux_test_check_selinux.sh
+++ b/scripts/test/install-linux_test_check_selinux.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export SHUNIT_RUNNIN=1
+export SHUNIT_RUNNING=1
 
 
 # Source install-linux.sh

--- a/scripts/test/install-linux_test_configure_openssh.sh
+++ b/scripts/test/install-linux_test_configure_openssh.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export SHUNIT_RUNNIN=1
+export SHUNIT_RUNNING=1
 
 
 # Source install-linux.sh

--- a/scripts/test/install-linux_test_configure_opkssh.sh
+++ b/scripts/test/install-linux_test_configure_opkssh.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export SHUNIT_RUNNIN=1
+export SHUNIT_RUNNING=1
 
 
 # Source install-linux.sh

--- a/scripts/test/install-linux_test_configure_sudo.sh
+++ b/scripts/test/install-linux_test_configure_sudo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export SHUNIT_RUNNIN=1
+export SHUNIT_RUNNING=1
 
 
 # Source install-linux.sh

--- a/scripts/test/install-linux_test_determine_linux_type.sh
+++ b/scripts/test/install-linux_test_determine_linux_type.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export SHUNIT_RUNNIN=1
+export SHUNIT_RUNNING=1
 
 
 # Source install-linux.sh

--- a/scripts/test/install-linux_test_display_help_message.sh
+++ b/scripts/test/install-linux_test_display_help_message.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export SHUNIT_RUNNIN=1
+export SHUNIT_RUNNING=1
 
 
 # Source install-linux.sh

--- a/scripts/test/install-linux_test_ensure_command.sh
+++ b/scripts/test/install-linux_test_ensure_command.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export SHUNIT_RUNNIN=1
+export SHUNIT_RUNNING=1
 
 
 # Source install-linux.sh

--- a/scripts/test/install-linux_test_ensure_openssh_server.sh
+++ b/scripts/test/install-linux_test_ensure_openssh_server.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export SHUNIT_RUNNIN=1
+export SHUNIT_RUNNING=1
 
 
 # Source install-linux.sh

--- a/scripts/test/install-linux_test_ensure_opkssh_user_and_group.sh
+++ b/scripts/test/install-linux_test_ensure_opkssh_user_and_group.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export SHUNIT_RUNNIN=1
+export SHUNIT_RUNNING=1
 
 
 # Source install-linux.sh

--- a/scripts/test/install-linux_test_env_var.sh
+++ b/scripts/test/install-linux_test_env_var.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export SHUNIT_RUNNIN=1
+export SHUNIT_RUNNING=1
 
 test_global_variables() {
     # Unset all related env vars to test default behavior

--- a/scripts/test/install-linux_test_helpers.sh
+++ b/scripts/test/install-linux_test_helpers.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export SHUNIT_RUNNIN=1
+export SHUNIT_RUNNING=1
 
 
 # Source install-linux.sh

--- a/scripts/test/install-linux_test_install_opkssh.sh
+++ b/scripts/test/install-linux_test_install_opkssh.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export SHUNIT_RUNNIN=1
+export SHUNIT_RUNNING=1
 
 
 # Source install-linux.sh

--- a/scripts/test/install-linux_test_log_opkssh.sh
+++ b/scripts/test/install-linux_test_log_opkssh.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export SHUNIT_RUNNIN=1
+export SHUNIT_RUNNING=1
 
 
 # Source install-linux.sh

--- a/scripts/test/install-linux_test_main.sh
+++ b/scripts/test/install-linux_test_main.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export SHUNIT_RUNNIN=1
+export SHUNIT_RUNNING=1
 
 
 # Source install-linux.sh

--- a/scripts/test/install-linux_test_parse_args.sh
+++ b/scripts/test/install-linux_test_parse_args.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export SHUNIT_RUNNIN=1
+export SHUNIT_RUNNING=1
 
 
 # Source install-linux.sh

--- a/scripts/test/install-linux_test_restart_openssh.sh
+++ b/scripts/test/install-linux_test_restart_openssh.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export SHUNIT_RUNNIN=1
+export SHUNIT_RUNNING=1
 
 
 # Source install-linux.sh

--- a/scripts/test/install-linux_test_running_as_root.sh
+++ b/scripts/test/install-linux_test_running_as_root.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export SHUNIT_RUNNIN=1
+export SHUNIT_RUNNING=1
 
 
 # Source install-linux.sh


### PR DESCRIPTION
The line 

```bash
if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
    main "$@"
    exit $?
fi
```
causes the install to be skipped when doing the default install procedure `wget -qO- "https://raw.githubusercontent.com/openpubkey/opkssh/main/scripts/install-linux.sh" | sudo bash`

I missed this during testing because I run the install script locally `./install-linux.sh` which passes the above check.