### PR TITLE
Improve checkOpenSSHVersion function

### DIFF
--- a/main.go
+++ b/main.go
@@ -318,18 +318,71 @@ func printConfigProblems() {
 // system running the verifier is greater than or equal to 8.1;
 // if not then prints a warning
 func checkOpenSSHVersion() {
-	// Redhat/centos does not recognize `sshd -V` but does recognize `ssh -V`
-	// Ubuntu recognizes both
-	cmd := exec.Command("ssh", "-V")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		log.Println("Warning: Error executing ssh -V:", err)
+	version := getOpenSSHVersion()
+	if version == "" {
+		log.Println("Warning: Could not determine OpenSSH version")
 		return
 	}
 
-	if ok, _ := isOpenSSHVersion8Dot1OrGreater(string(output)); !ok {
+	if ok, _ := isOpenSSHVersion8Dot1OrGreater(version); !ok {
 		log.Println("Warning: OpenPubkey SSH requires OpenSSH v. 8.1 or greater")
 	}
+}
+
+// getOpenSSHVersion attempts to get OpenSSH version using multiple fallback methods
+func getOpenSSHVersion() string {
+	// Try ssh -V first (works on most systems)
+	cmd := exec.Command("ssh", "-V")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return string(output)
+	}
+	log.Println("Warning: Error executing ssh -V:", err)
+
+	// Try sshd -V as fallback
+	cmd = exec.Command("sshd", "-V")
+	output, err = cmd.CombinedOutput()
+	if err == nil {
+		return string(output)
+	}
+	log.Println("Warning: Error executing sshd -V:", err)
+
+	// Fall back to OS-specific package manager queries
+	osType := detectOS()
+	log.Printf("Attempting OS-specific version detection for: %s", osType)
+
+	switch osType {
+	case OSTypeRHEL:
+		// For RedHat-based systems (CentOS, RHEL, Fedora)
+		cmd = exec.Command("sh", "-c", "version=$(rpm -q --qf \"%{VERSION}\\n\" openssh-server | sed -E 's/^([0-9]+\\.[0-9]+).*/\\1/'); echo \"OpenSSH_$version\"")
+		if output, err := cmd.CombinedOutput(); err == nil {
+			return string(output)
+		}
+
+	case OSTypeDebian:
+		// For Debian-based systems (Debian, Ubuntu)
+		cmd = exec.Command("sh", "-c", "version=$(dpkg-query -W -f='${Version}\\n' openssh-server | sed -E 's/^[0-9]*:?([0-9]+\\.[0-9]+).*/\\1/'); echo \"OpenSSH_$version\"")
+		if output, err := cmd.CombinedOutput(); err == nil {
+			return string(output)
+		}
+
+	case OSTypeArch:
+		// For Arch Linux
+		cmd = exec.Command("sh", "-c", "version=$(pacman -Qi openssh | awk '/^Version/ {print $3}' | sed -E 's/^([0-9]+\\.[0-9]+).*/\\1/'); echo \"OpenSSH_$version\"")
+		if output, err := cmd.CombinedOutput(); err == nil {
+			return string(output)
+		}
+
+	case OSTypeSUSE:
+		// For SUSE-based systems
+		cmd = exec.Command("sh", "-c", "version=$(rpm -q --qf \"%{VERSION}\\n\" openssh | sed -E 's/^([0-9]+\\.[0-9]+).*/\\1/'); echo \"OpenSSH_$version\"")
+		if output, err := cmd.CombinedOutput(); err == nil {
+			return string(output)
+		}
+	}
+
+	log.Printf("Warning: Could not determine OpenSSH version using OS-specific methods for %s", osType)
+	return ""
 }
 
 func isOpenSSHVersion8Dot1OrGreater(opensshVersion string) (bool, error) {
@@ -359,4 +412,66 @@ func isOpenSSHVersion8Dot1OrGreater(opensshVersion string) (bool, error) {
 	}
 
 	return false, nil
+}
+
+// OSType represents the operating system type
+type OSType string
+
+// Operating system constants
+const (
+	OSTypeGeneric OSType = "generic"
+	OSTypeRHEL    OSType = "rhel"
+	OSTypeDebian  OSType = "debian"
+	OSTypeArch    OSType = "arch"
+	OSTypeSUSE    OSType = "suse"
+)
+
+// detectOS determines the type of operating system.
+func detectOS() OSType {
+	// Check for RedHat-based systems
+	if _, err := os.Stat("/etc/redhat-release"); err == nil {
+		return OSTypeRHEL
+	}
+
+	// Check for Debian-based systems
+	if _, err := os.Stat("/etc/debian_version"); err == nil {
+		return OSTypeDebian
+	}
+
+	// Check for Arch Linux
+	if _, err := os.Stat("/etc/arch-release"); err == nil {
+		return OSTypeArch
+	}
+
+	// Check for SUSE Linux
+	if _, err := os.Stat("/etc/SuSE-release"); err == nil {
+		return OSTypeSUSE
+	}
+	if _, err := os.Stat("/etc/SUSE-brand"); err == nil {
+		return OSTypeSUSE
+	}
+
+	// Check for /etc/os-release which exists on most modern Linux systems
+	if content, err := os.ReadFile("/etc/os-release"); err == nil {
+		contentStr := string(content)
+		if strings.Contains(contentStr, "ID=rhel") ||
+			strings.Contains(contentStr, "ID=centos") ||
+			strings.Contains(contentStr, "ID=fedora") {
+			return OSTypeRHEL
+		}
+		if strings.Contains(contentStr, "ID=debian") ||
+			strings.Contains(contentStr, "ID=ubuntu") {
+			return OSTypeDebian
+		}
+		if strings.Contains(contentStr, "ID=arch") {
+			return OSTypeArch
+		}
+		if strings.Contains(contentStr, "ID=sles") ||
+			strings.Contains(contentStr, "ID=opensuse") {
+			return OSTypeSUSE
+		}
+	}
+
+	// Default to generic, if no specific OS type is detected.
+	return OSTypeGeneric
 }

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -472,7 +472,6 @@ module opkssh 1.0;
 require {
         type sshd_t;
         type var_log_t;
-        type ssh_exec_t;
         type http_port_t;
         type sudo_exec_t;
         class file { append execute execute_no_trans open read map };
@@ -485,13 +484,10 @@ require {
 # 1. Make TCP connections to ports labeled http_port_t. This is so opkssh can download the public keys of the OpenID providers.
 allow sshd_t http_port_t:tcp_socket name_connect;
 
-# 2. Needed to allow opkssh to call `ssh -V` to determine if the version is supported by opkssh
-allow sshd_t ssh_exec_t:file { execute execute_no_trans open read map };
-
-# 3. Needed to allow opkssh to call `sudo opkssh readhome` to read the policy file in the user's home directory
+# 2. Needed to allow opkssh to call `sudo opkssh readhome` to read the policy file in the user's home directory
 allow sshd_t sudo_exec_t:file { execute execute_no_trans open read map };
 
-# 4. Needed to allow opkssh to write to its log file
+# 3. Needed to allow opkssh to write to its log file
 allow sshd_t var_log_t:file { open append };
 EOF
 
@@ -509,7 +505,6 @@ module opkssh-no-home 1.0;
 require {
         type sshd_t;
         type var_log_t;
-        type ssh_exec_t;
         type http_port_t;
         class file { append execute execute_no_trans open read map };
         class tcp_socket name_connect;
@@ -521,10 +516,7 @@ require {
 # 1. Make TCP connections to ports labeled http_port_t. This is so opkssh can download the public keys of the OpenID providers.
 allow sshd_t http_port_t:tcp_socket name_connect;
 
-# 2. Needed to allow opkssh to call `ssh -V` to determine if the version is supported by opkssh
-allow sshd_t ssh_exec_t:file { execute execute_no_trans open read map };
-
-# 3. Needed to allow opkssh to write to its log file
+# 2. Needed to allow opkssh to write to its log file
 allow sshd_t var_log_t:file { open append };
 EOF
             fi

--- a/scripts/test/install-linux_test_check_selinux.sh
+++ b/scripts/test/install-linux_test_check_selinux.sh
@@ -90,7 +90,6 @@ module opkssh 1.0;
 require {
         type sshd_t;
         type var_log_t;
-        type ssh_exec_t;
         type http_port_t;
         type sudo_exec_t;
         class file { append execute execute_no_trans open read map };
@@ -103,13 +102,10 @@ require {
 # 1. Make TCP connections to ports labeled http_port_t. This is so opkssh can download the public keys of the OpenID providers.
 allow sshd_t http_port_t:tcp_socket name_connect;
 
-# 2. Needed to allow opkssh to call \`ssh -V\` to determine if the version is supported by opkssh
-allow sshd_t ssh_exec_t:file { execute execute_no_trans open read map };
-
-# 3. Needed to allow opkssh to call \`sudo opkssh readhome\` to read the policy file in the user's home directory
+# 2. Needed to allow opkssh to call \`sudo opkssh readhome\` to read the policy file in the user's home directory
 allow sshd_t sudo_exec_t:file { execute execute_no_trans open read map };
 
-# 4. Needed to allow opkssh to write to its log file
+# 3. Needed to allow opkssh to write to its log file
 allow sshd_t var_log_t:file { open append };
 END
 )
@@ -137,7 +133,6 @@ module opkssh-no-home 1.0;
 require {
         type sshd_t;
         type var_log_t;
-        type ssh_exec_t;
         type http_port_t;
         class file { append execute execute_no_trans open read map };
         class tcp_socket name_connect;
@@ -149,10 +144,7 @@ require {
 # 1. Make TCP connections to ports labeled http_port_t. This is so opkssh can download the public keys of the OpenID providers.
 allow sshd_t http_port_t:tcp_socket name_connect;
 
-# 2. Needed to allow opkssh to call \`ssh -V\` to determine if the version is supported by opkssh
-allow sshd_t ssh_exec_t:file { execute execute_no_trans open read map };
-
-# 3. Needed to allow opkssh to write to its log file
+# 2. Needed to allow opkssh to write to its log file
 allow sshd_t var_log_t:file { open append };
 semodule_package -o /tmp/opkssh-no-home.pp -m /tmp/opkssh-no-home.mod
 semodule -i /tmp/opkssh-no-home.pp


### PR DESCRIPTION
This is my proposal.

I tested it manually against different containers (RedHat, Debian, Arch, SUSE), and the output I get is compatible with what isOpenSSHVersion8Dot1OrGreater accepts (i.e., OpenSSH_9.2).

The fallback strategy ensures that we first try the command most likely to succeed (ssh -V), and if that fails, we attempt to detect the SSH version by querying the OS package manager directly.

It's a bit difficult to test, but I’m confident it works better than before. I’m open to suggestions to increase confidence before merging.