### PR TITLE
ci: fix zizmor findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
     name: Shell Scripts Lint & Test
     runs-on: ubuntu-latest
     container:
-      image: opensuse/tumbleweed
+      image: opensuse/tumbleweed@sha256:0e4012a3252d314963671177d6f2a5c7a8e5b47c7b1f1ce98ed9b8d0423d7950
     steps:
     - name: Install packages
       run: |

--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
     - name: Build and export to Docker
-      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6 # zizmor: ignore[cache-poisoning]
       with:
         build-args: |
           AUTHORIZED_REPOSITORY=${{ github.repository }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   update_release_draft:
+    name: Update Release Draft
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -9,6 +9,7 @@ permissions: {}
 
 jobs:
   lockfile:
+    name: Update flake.lock
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
I have disabled the cache-poisoning finding in the test, rather than fix it, because this is primarily a risk in release workflows where attackers might overwrite the release artifacts. I rather take the speed advantage in our test suite. 