### PR TITLE
Add description for OPKSSH command-line tool

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+/*
+OPKSSH is a command-line tool that allows users to authenticate with OpenID Connect providers and generate SSH keys for secure access to servers.
+*/
 package main
 
 import (


### PR DESCRIPTION
This will fix the "There is no documentation for this package"

<img width="818" height="225" alt="image" src="https://github.com/user-attachments/assets/feeb090d-312d-49d5-8f2b-57438ab7321f" />
