### PR TITLE
Fixes typo in linux install script and docs (regression)

### DIFF
--- a/scripts/install-linux-script.md
+++ b/scripts/install-linux-script.md
@@ -308,7 +308,7 @@ configure_openssh_server
 Configure openSSH-server to use opkssh using AuthorizedKeysCommand
 
 **Arguments:**
--   $1 - Path to ssh root configuratino directory (Optional, default /etc/ssh)
+-   $1 - Path to ssh root configuration directory (Optional, default /etc/ssh)
 
 Output:
   Writes to stdout the progress of configuration

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -621,7 +621,7 @@ configure_opkssh() {
 # Configure openSSH-server to use opkssh using AuthorizedKeysCommand
 #
 # Arguments:
-#   $1 - Path to ssh root configuratino directory (Optional, default /etc/ssh)
+#   $1 - Path to ssh root configuration directory (Optional, default /etc/ssh)
 #
 # Output:
 #   Writes to stdout the progress of configuration


### PR DESCRIPTION
Fixes a small typo in `install-linux.sh` and `install-linux-script.md` 

It was previously fixed in the PR #304 but only in the  `install-linux-script.md` , and since I missed that PR and that file is generated by running the scripts/generate-doc.sh file it was introduced again with PR #276
