### PR TITLE
fix: Fixes URL in get_te_download_path

### DIFF
--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -383,7 +383,7 @@ get_te_download_path() {
     else
         version="$INSTALL_VERSION"
     fi
-    te_url="https://raw.githubusercontent.com/${GITHUB_REPO}/${version}/te_files/opkssh"
+    te_url="https://raw.githubusercontent.com/${GITHUB_REPO}/refs/tags/${version}/te-files/opkssh"
 
     if [[ "$HOME_POLICY" == true ]]; then
         te_url="${te_url}.te"

--- a/scripts/test/install-linux_test_get_te_download_path.sh
+++ b/scripts/test/install-linux_test_get_te_download_path.sh
@@ -17,7 +17,7 @@ test_get_te_download_path_latest_version_with_home_policy_true() {
     export HOME_POLICY=true
 
     result=$(get_te_download_path)
-    expected="https://raw.githubusercontent.com/my-org/my-repo/v1.2.3/te_files/opkssh.te"
+    expected="https://raw.githubusercontent.com/my-org/my-repo/refs/tags/v1.2.3/te-files/opkssh.te"
 
     assertEquals "$expected" "$result"
 }
@@ -28,7 +28,7 @@ test_specific_version_no_home() {
     export HOME_POLICY=false
 
     result=$(get_te_download_path)
-    expected="https://raw.githubusercontent.com/org/repo/v1.0.0/te_files/opkssh-no-home.te"
+    expected="https://raw.githubusercontent.com/org/repo/refs/tags/v1.0.0/te-files/opkssh-no-home.te"
 
     assertEquals "$expected" "$result"
 }


### PR DESCRIPTION
The `get_te_download_path` resolved to the wrong URL, this PR sets the correct download path for TE files
fixes #323 