### PR TITLE
fix: Fixes build since /var/run/sshd already created

### DIFF
--- a/.github/workflows/gha_opkssh.Dockerfile
+++ b/.github/workflows/gha_opkssh.Dockerfile
@@ -19,7 +19,8 @@ RUN  echo "test:test" | chpasswd
 RUN echo "test ALL=(ALL:ALL) NOPASSWD: ALL" | tee /etc/sudoers.d/test
 
 # Allow SSH access
-RUN mkdir /var/run/sshd
+# This directory is automatically created on the latest docker image
+# RUN mkdir /var/run/sshd
 
 # Expose SSH server so we can ssh in from the tests
 EXPOSE 22


### PR DESCRIPTION
Same issue as https://github.com/openpubkey/opkssh/pull/321/commits/21a9a43789c8bbf3f6a5ab06d10783724790f2ea 

```
RUN mkdir /var/run/sshd
```

Fails because on some newer docker images sshd is already created. Previously did this on the integration test docker images. Now hitting this on the github action docker image.