### PR TITLE
[feat] Add new "inspect" subcommand

### DIFF
--- a/commands/inspect.go
+++ b/commands/inspect.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/openpubkey/openpubkey/pktoken"
+	"golang.org/x/crypto/ssh"
+)
+
+type InspectCmd struct {
+	// KeyOrCert is the SSH key or certificate to be inspected.
+	KeyOrCert string
+	// Output is where output should be written to.
+	Output io.Writer
+}
+
+// NewInspectCmd creates a new InspectCmd instance with the provided arguments.
+func NewInspectCmd(keyOrCert string, output io.Writer) *InspectCmd {
+	return &InspectCmd{
+		KeyOrCert: keyOrCert,
+		Output:    output,
+	}
+}
+
+// printf formats a string to the configured output.
+func (i *InspectCmd) printf(format string, a ...any) {
+	if _, err := fmt.Fprintf(i.Output, format, a...); err != nil {
+		// Fall back to stdout
+		i.printf(format, a...)
+	}
+}
+
+func (i *InspectCmd) Run() error {
+	// Check if the input is a file path
+	if _, err := os.Stat(i.KeyOrCert); err == nil {
+		// It's a file, read its contents
+		data, err := os.ReadFile(i.KeyOrCert)
+		if err != nil {
+			return fmt.Errorf("error reading input file: %v", err)
+		}
+		i.KeyOrCert = string(data)
+	}
+
+	// Trim whitespace and newlines
+	i.KeyOrCert = strings.TrimSpace(i.KeyOrCert)
+
+	// Parse the SSH key or certificate
+	pubKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(i.KeyOrCert))
+	if err != nil {
+		return fmt.Errorf("failed to parse SSH key: %v", err)
+	}
+
+	// Check if it's a certificate
+	if cert, ok := pubKey.(*ssh.Certificate); ok {
+		i.inspectCertificate(cert)
+	} else {
+		// It's a regular public key
+		i.inspectPublicKey(pubKey)
+	}
+
+	return nil
+}
+
+func (i *InspectCmd) inspectCertificate(cert *ssh.Certificate) {
+	i.printf("--- SSH Certificate Information ---\n")
+	i.printf("%-18s %d\n", "Serial:", cert.Serial)
+	i.printf("%-18s %s\n", "Type:", certificateType(cert.CertType))
+	i.printf("%-18s %s\n", "Key ID:", cert.KeyId)
+	i.printf("%-18s %v\n", "Principals:", cert.ValidPrincipals)
+	i.printf("%-18s %s\n", "Valid After:", formatTime(cert.ValidAfter))
+	i.printf("%-18s %s\n", "Valid Before:", formatTime(cert.ValidBefore))
+	i.printf("%-18s %v\n", "Critical Options:", cert.CriticalOptions)
+
+	// Format extensions nicely
+	i.printf("Extensions:\n")
+	for key, value := range cert.Extensions {
+		if key == "openpubkey-pkt" {
+			i.printf("  %s: [PKToken data] %d bytes\n", key, len(value))
+		} else {
+			i.printf("  %s: %s\n", key, value)
+		}
+	}
+
+	// Extract openpubkey-pkt extension if it exists
+	pktStr, ok := cert.Extensions["openpubkey-pkt"]
+	if !ok {
+		i.printf("\nNo openpubkey-pkt extension found\n")
+		return
+	}
+
+	i.inspectPKToken(pktStr)
+}
+
+// formatTime converts a Unix timestamp to a readable date string
+func formatTime(timestamp uint64) string {
+	if timestamp == 0 {
+		return "Not set"
+	}
+	if timestamp == 1<<64-1 {
+		return "Forever"
+	}
+	t := time.Unix(int64(timestamp), 0)
+	return t.Format(time.RFC3339)
+}
+
+func (i *InspectCmd) inspectPublicKey(pubKey ssh.PublicKey) {
+	i.printf("--- SSH Public Key Information ---\n")
+	i.printf("Type: %s\n", pubKey.Type())
+
+	// Get fingerprint
+	fingerprint := ssh.FingerprintSHA256(pubKey)
+	i.printf("Fingerprint: %s\n", fingerprint)
+
+	// Get marshal format
+	marshal := base64.StdEncoding.EncodeToString(pubKey.Marshal())
+	i.printf("Marshal (base64): %s...\n", marshal[:20])
+}
+
+func certificateType(certType uint32) string {
+	switch certType {
+	case ssh.UserCert:
+		return "User Certificate"
+	case ssh.HostCert:
+		return "Host Certificate"
+	}
+	return fmt.Sprintf("Unknown (%d)", certType)
+}
+
+func (i *InspectCmd) inspectPKToken(pktStr string) {
+	// Parse the PKToken
+	pkt, err := pktoken.NewFromCompact([]byte(pktStr))
+	if err != nil {
+		i.printf("Error parsing PKToken: %v\n", err)
+		return
+	}
+
+	// Print token structure and metadata
+	i.printf("\n--- PKToken Structure ---\n")
+	i.printf("Payload:\n")
+	i.printJSON(pkt.Payload)
+
+	// Print signature information
+	i.printf("\n--- Signature Information ---\n")
+	if pkt.Op != nil {
+		i.printf("Provider Signature (OP) exists\n")
+	}
+	if pkt.Cic != nil {
+		i.printf("Client Signature (CIC) exists\n")
+	}
+	if pkt.Cos != nil {
+		i.printf("Cosigner Signature (COS) exists\n")
+	}
+
+	// Print token metadata
+	i.printf("\n--- Token Metadata ---\n")
+	i.printTokenMetadata(pkt)
+}
+
+func (i *InspectCmd) printJSON(data []byte) {
+	var obj any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		i.printf("Error unmarshalling JSON: %v\n", err)
+		i.printf("%s\n", string(data))
+		return
+	}
+
+	pretty, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		i.printf("Error pretty-printing: %v\n", err)
+		i.printf("%s\n", string(data))
+		return
+	}
+
+	i.printf("%s\n", string(pretty))
+}
+
+func (i *InspectCmd) printTokenMetadata(pkt *pktoken.PKToken) {
+	// Extract common token claims
+	if issuer, err := pkt.Issuer(); err == nil {
+		i.printf("%-19s %s\n", "Issuer:", issuer)
+	}
+
+	if aud, err := pkt.Audience(); err == nil {
+		i.printf("%-19s %s\n", "Audience:", aud)
+	}
+
+	if sub, err := pkt.Subject(); err == nil {
+		i.printf("%-19s %s\n", "Subject:", sub)
+	}
+
+	if identity, err := pkt.IdentityString(); err == nil {
+		i.printf("%-19s %s\n", "Identity:", identity)
+	}
+
+	// Print token hash (useful for identifying tokens)
+	if hash, err := pkt.Hash(); err == nil {
+		i.printf("%-19s %s\n", "Token Hash:", hash)
+	}
+
+	// Print provider algorithm if available
+	if alg, ok := pkt.ProviderAlgorithm(); ok {
+		i.printf("%-19s %s\n", "Provider Algorithm:", alg)
+	}
+}

--- a/commands/inspect_test.go
+++ b/commands/inspect_test.go
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInspectCmdPrintf(t *testing.T) {
+	buf := new(bytes.Buffer)
+	inspect := NewInspectCmd("foo", buf)
+	inspect.printf("Answer: %d", 42)
+
+	output := buf.String()
+	require.Contains(t, output, "Answer: 42")
+}
+
+func TestInspectCmdJson(t *testing.T) {
+	inputString := `{"name":"test","options":["one","two"]}`
+	input := []byte(inputString)
+	outputBuf := new(bytes.Buffer)
+
+	inspect := NewInspectCmd("foo", outputBuf)
+	inspect.printJSON(input)
+
+	output := outputBuf.String()
+	require.Contains(t, output, `"name": "test",`)
+	require.Contains(t, output, `"one",`)
+	require.Contains(t, output, ` "two"`)
+}
+
+func TestInspectCmd(t *testing.T) {
+	dummyKey := "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINlDR6KRBqBZ1/UL96ltcZWQC7QTgru/ckbCrA/i3RfI your_email@example.com"
+
+	f, err := os.CreateTemp("", "opkssh")
+	require.NoError(t, err, "unable to create test file")
+
+	_, err = f.WriteString(dummyKey)
+	require.NoError(t, err, "unable to write test file")
+	f.Close()
+	defer os.Remove(f.Name())
+
+	dummyFile := f.Name()
+
+	tests := []struct {
+		name        string
+		input       string
+		wantError   bool
+		errorString string
+	}{
+		{
+			name:        "Invalid input",
+			input:       "scoobydoowhereareyou",
+			wantError:   true,
+			errorString: "failed to parse SSH key",
+		},
+		{
+			name:      "Direct input",
+			input:     dummyKey,
+			wantError: false,
+		},
+		{
+			name:      "File input",
+			input:     dummyFile,
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			inspect := NewInspectCmd(tt.input, buf)
+
+			err := inspect.Run()
+
+			if tt.wantError {
+				require.Error(t, err, "Expected error but got none")
+				if tt.errorString != "" {
+					require.ErrorContains(t, err, tt.errorString, "Got a wrong error message")
+				}
+			} else {
+				require.NoError(t, err, "Unexpected error")
+
+				output := buf.String()
+				require.Contains(t, output, "--- SSH Public Key Information ---")
+				require.Contains(t, output, "Type: ssh-ed25519")
+				require.Contains(t, output, "AAAAC3NzaC")
+			}
+		})
+	}
+}
+
+func TestInspectFormatTime(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name         string
+		input        uint64
+		outputString string
+	}{
+		{
+			name:         "epoch",
+			input:        0,
+			outputString: "Not set",
+		},
+		{
+			name:         "forever",
+			input:        18446744073709551615,
+			outputString: "Forever",
+		},
+		{
+			name:         "regular timestamp",
+			input:        uint64(now.Unix()),
+			outputString: now.Format(time.RFC3339),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := formatTime(tt.input)
+			require.Equal(t, tt.outputString, output)
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -30,8 +30,7 @@ import (
 	"regexp"
 	"strings"
 	"syscall"
-
-	"github.com/thediveo/enumflag/v2"
+	"text/tabwriter"
 
 	"github.com/openpubkey/opkssh/commands"
 	config "github.com/openpubkey/opkssh/commands/config"
@@ -39,8 +38,8 @@ import (
 	"github.com/openpubkey/opkssh/policy/files"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"github.com/thediveo/enumflag/v2"
 	"golang.org/x/term"
-	"text/tabwriter"
 )
 
 var (
@@ -123,6 +122,24 @@ Arguments:
 		},
 	}
 	rootCmd.AddCommand(addCmd)
+
+	inspectCmd := &cobra.Command{
+		SilenceUsage: true,
+		Use:          "inspect <path>",
+		Short:        "Inspect and view details of an opkssh generated SSH key",
+		Example:      "  opkssh inspect ~/.ssh/id_ecdsa_sk-cert.pub",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			keyPathArg := args[0]
+			inspect := commands.NewInspectCmd(keyPathArg, cmd.OutOrStdout())
+			if err := inspect.Run(); err != nil {
+				log.Println("Error executing inspect command:", err)
+				return err
+			}
+			return nil
+		},
+		Args: cobra.ExactArgs(1),
+	}
+	rootCmd.AddCommand(inspectCmd)
 
 	var autoRefreshArg bool
 	var configPathArg string


### PR DESCRIPTION
We've had an unfortunately semi-frequent need to debug issues with certificates. Inspecting cert details was a challenge being converting its format into something that is more easily understood.

This proposes a new `opkssh inspect` subcommand that can be used under these situations to be able to view things like group grants and other details.

## Example output

Example output from running the command `opkssh inspect ~/.ssh/id_ecdsa_sk-cert.pub`:

```txt
Key ID:            me@example.com
Principals:        []
Valid After:       Not set
Valid Before:      Forever
Critical Options:  map[]
Extensions:
  openpubkey-pkt: [PKToken data]
  permit-X11-forwarding: 
  permit-agent-forwarding: 
  permit-port-forwarding: 
  permit-pty: 
  permit-user-rc: 

--- PKToken Structure ---
Payload:
{
  "amr": [
    "swk",
    "mfa",
    "pwd"
  ],
  "at_hash": "r_DWPANiT5J3zxxXnntxxx",
  "aud": "0oasfec4a6mj1tJuxxxx",
  "auth_time": 1758907797,
  "email": "me@example.com",
  "exp": 1758917415,
  "groups": [
    "Engineering",
    "Monkeys"
  ],
  "iat": 1758913825,
  "idp": "00o4fjbv8sxxxa9J1xxx",
  "iss": "https://x.example.com",
  "jti": "ID.jsh0FXxxxWgRS5SEGUmWRk-0MYmxf62nnyzqonCLxxx",
  "nonce": "xxx2KgTsQPSAZrcLmgokz2rsWBF-Tzf3UU2pEDrcxxx",
  "sub": "00u8zk7zs77cubn4oxxx",
  "ver": 1
}

--- Signature Information ---
Provider Signature (OP) exists
Client Signature (CIC) exists

--- Token Metadata ---
Issuer:             https://x.example.com
Audience:           0oasfec4a6mj1tJu6xxx
Subject:            00u8zk7zs77cubn4oxxx
Identity:           00u8zk7zs77cubn4oxxx https://x.example.com
Token Hash:         Z9O-T5EjT3exxxlaL8WdZtLoRam0wO6Fhbt9sNItxxx
Provider Algorithm: RS256

--- ID Token Payload ---
```