### PR TITLE
Add filepath flag to readhome

### DIFF
--- a/commands/readhome_test.go
+++ b/commands/readhome_test.go
@@ -1,0 +1,64 @@
+// Copyright 2025 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux || darwin
+
+package commands
+
+import (
+	"os/user"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadHomeCmd(t *testing.T) {
+	t.Parallel()
+
+	homePolicyPath := "/home/alice/.opk/fake-path/1234_auth_id"
+	validUser := &user.User{HomeDir: "/home/foo", Username: "foo"}
+
+	// Test before we have setup the mocks, should error
+	readHomeCmd := NewReadHomeCmd()
+	policyFile, err := readHomeCmd.ReadHome(validUser.Username, homePolicyPath)
+
+	require.Error(t, err, "expected error for nonexistent user")
+	require.Nil(t, policyFile, "expected nil policyFile for nonexistent user")
+
+	// Setup the mocks
+	mockFs := afero.NewMemMapFs()
+	readHomeCmd.Fs = mockFs
+	readHomeCmd.UserLookup = &MockUserLookup{User: validUser}
+
+	err = afero.WriteFile(mockFs, homePolicyPath, []byte("123456"), 0600)
+	require.NoError(t, err, "failed to write mock home policy file")
+
+	defaultHomePolicyPath := filepath.Join(validUser.HomeDir, ".opk", "auth_id")
+	err = afero.WriteFile(mockFs, defaultHomePolicyPath, []byte("ABCDEF"), 0600)
+	require.NoError(t, err, "failed to write mock default home policy file")
+
+	policyFile, err = readHomeCmd.ReadHome(validUser.Username, "")
+	require.NoError(t, err, "expected no error for valid user and existing file")
+	require.NotNil(t, policyFile, "expected non-nil policyFile for valid user and existing file")
+	require.Equal(t, []byte("ABCDEF"), policyFile, "unexpected policy file contents (default path)")
+
+	policyFile, err = readHomeCmd.ReadHome(validUser.Username, homePolicyPath)
+	require.NoError(t, err, "expected no error for valid user and existing file")
+	require.NotNil(t, policyFile, "expected non-nil policyFile for valid user and existing file")
+	require.Equal(t, []byte("123456"), policyFile, "unexpected policy file contents (path overridden)")
+}

--- a/commands/readhome_windows.go
+++ b/commands/readhome_windows.go
@@ -20,9 +20,23 @@ package commands
 
 import (
 	"errors"
+
+	"github.com/spf13/afero"
 )
 
+// ReadHomeCmd provides functionality to read the home policy file for a user.
+type ReadHomeCmd struct {
+	Fs afero.Fs
+}
+
 // ReadHome is not currently supported on Windows
-func ReadHome(username string) ([]byte, error) {
+func NewReadHomeCmd() *ReadHomeCmd {
+	return &ReadHomeCmd{
+		Fs: afero.NewOsFs(),
+	}
+}
+
+// ReadHome is not currently supported on Windows
+func (r *ReadHomeCmd) ReadHome(username string, homePolicyPathArg string) ([]byte, error) {
 	return nil, errors.New("readhome not supported on windows")
 }

--- a/main.go
+++ b/main.go
@@ -207,6 +207,7 @@ Arguments:
 	loginCmd.Flags().VarP(enumflag.New(&keyTypeArg, "Key Type", map[commands.KeyType][]string{commands.ECDSA: {commands.ECDSA.String()}, commands.ED25519: {commands.ED25519.String()}}, enumflag.EnumCaseInsensitive), "key-type", "t", "Type of key to generate")
 	rootCmd.AddCommand(loginCmd)
 
+	var homePolicyPathArg string
 	readhomeCmd := &cobra.Command{
 		SilenceUsage: true,
 		Use:          "readhome <principal>",
@@ -219,7 +220,8 @@ You should not call this command directly. It is called by the opkssh verify com
 		Example: `  opkssh readhome alice`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			userArg := os.Args[2]
-			if fileBytes, err := commands.ReadHome(userArg); err != nil {
+			readHomeCmd := commands.NewReadHomeCmd()
+			if fileBytes, err := readHomeCmd.ReadHome(userArg, homePolicyPathArg); err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to read user's home policy file: %v\n", err)
 				return err
 			} else {
@@ -228,6 +230,7 @@ You should not call this command directly. It is called by the opkssh verify com
 			}
 		},
 	}
+	readhomeCmd.Flags().StringVarP(&homePolicyPathArg, "home-policy-path", "f", "", "Optional path to the user's home policy file (/home/alice/.opk/auth_id_1234). It is intended for update scripts that run opkssh against a temp policy files to determine if the policy update is safe. If this flag is provided, it will be used to compute the filepath to the home policy file instead of the username. It will still check that the user exists.")
 	rootCmd.AddCommand(readhomeCmd)
 
 	var serverConfigPathArg string

--- a/main_test.go
+++ b/main_test.go
@@ -268,6 +268,12 @@ func TestRun(t *testing.T) {
 				"hello     https://issuer.hello.coop\n",
 			wantExit: 0,
 		},
+		{
+			name:       "Readhome wrong --home-policy-path",
+			args:       []string{"opkssh", "readhome", "alice", "--home-policy-path=/non/existent/path"},
+			wantOutput: "Failed to read user's home policy file",
+			wantExit:   1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Address https://github.com/openpubkey/opkssh/issues/429 by creating a filepath flag to readhome

This is insecure and should not be used, [see thread here ](https://github.com/openpubkey/opkssh/pull/396) which I've duplicated below

readhome works like this:

ssh-server --> `opkssh verify <username> ...` --> `sudo opkssh readhome <username>` --> reads `/home/<username>/.opk/auth_id` and returns the contains to opkssh verify as output

The problems
====

1. If we modify `opkssh readhome` to accept a new filepath, `opkssh verify` won't know to supply that new filepath. 

2. Even worse such a flag is insecure because it lets the `sudo opkssh readhome --home-policy-path=...` read any file on the file system. The readhome command is specifically designed so that it can only read a specify file to scope the damage if the `opkssh verify` process is compromised.

3. Readhome does not check if the policy file is correct, you would need to write a script to call `opkssh verify <username> ...`