### PR TITLE
Fix integration tests failing due to pacman keys

### DIFF
--- a/test/integration/openssh_version_test.go
+++ b/test/integration/openssh_version_test.go
@@ -75,9 +75,8 @@ func TestOpenSSHVersionDetection(t *testing.T) {
 			setupCommands: []string{
 				"pacman-key --init",
 				"pacman-key --populate archlinux manjaro",
-				"pacman -Syyu --noconfirm",
-				"pacman -S --noconfirm --needed manjaro-keyring archlinux-keyring || true",
-				"pacman -S --noconfirm --needed openssh sed",
+				"pacman -Sy --noconfirm --needed manjaro-keyring archlinux-keyring",
+				"pacman -Sy --noconfirm --needed openssh sed",
 			},
 			versionCommand: `version=$(/usr/bin/pacman -Qi openssh | /usr/bin/awk '/^Version/ {print $3}' | /bin/sed -E 's/^([0-9]+\.[0-9]+).*/\1/'); /bin/echo "OpenSSH_$version"`,
 			expectedPrefix: "OpenSSH_",


### PR DESCRIPTION
Fixes the error where we don't have the pacman keys to verify the packages we are installing. Required tweaking some of the keys field

```
openssh_version_test.go:120: Running setup command: pacman-key --populate archlinux manjaro
openssh_version_test.go:120: Running setup command: pacman -Syyu --noconfirm
openssh_version_test.go:124: 
Error Trace:	/home/runner/work/opkssh/opkssh/test/integration/openssh_version_test.go:124
/home/runner/work/opkssh/opkssh/test/integration/openssh_version_test.go:89
Error:      	Not equal: 
expected: 0
actual  : 1
Test:       	TestOpenSSHVersionDetection/Arch_Linux
```