### PR TITLE
Update hack.sh to use user ids as user ids, not group ids as user ids

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -14,7 +14,7 @@ mkdir -p .mod-cache
 docker run --rm \
     -v "$PWD":/data/ \
     -w /data \
-    --user=$(id -g):$(id -g) \
+    --user=$(id -u):$(id -g) \
     -v ${PWD}/.cache:/.cache \
     -v ${PWD}/.mod-cache:/go/pkg/mod \
     golang:${GO_VERSION}-alpine \


### PR DESCRIPTION
Not all operating systems implement [User Private Groups](https://wiki.debian.org/UserPrivateGroups) by default. When running `/hack/build.sh` on such a system (one where there is not a group with a gid that matches the user uid), the variable substitution in `docker run` breaks.

All that to say, `id -u` added

```console
❯ set -ex
❯ ./hack/build.sh
+++ dirname -- ./hack/build.sh
++ cd -- ./hack
++ pwd
+ SCRIPT_DIR=/home/notroot/git/opkssh/hack
+ set -eou pipefail
+ pushd /home/notroot/git/opkssh/hack/../
~/git/opkssh ~/git/opkssh
+ GO_VERSION=1.24.2
+ mkdir -p .cache
+ mkdir -p .mod-cache
++ id -g
++ id -g
+ docker run --rm -v /home/notroot/git/opkssh:/data/ -w /data --user=100:100 -v /home/notroot/git/opkssh/.cache:/.cache -v /home/notroot/git/opkssh/.mod-cache:/go/pkg/mod golang:1.24.2-alpine go build -v -o opkssh
failed to initialize build cache at /.cache/go-build: mkdir /.cache/go-build: permission denied
❯ id
uid=1000(notroot) gid=100(users) groups=100(users),1(wheel),17(audio),57(networkmanager),131(docker),988(gamemode),992(rtkit)
❯ id -g
100
❯ id -u
1000
```