### PR TITLE
fix(ci): use `go run .` instead of `go run main.go` in gha workflow

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -46,7 +46,7 @@ jobs:
       run: docker run -d -p 2222:22 sshserver:latest
 
     - name: Login
-      run: go run main.go login github --print-id-token
+      run: go run . login github --print-id-token
 
     - name: SSH into Container with opkssh
       run: |


### PR DESCRIPTION
## Problem

After merging PR #480 (Add Windows SSH server support), the [Test GitHub Provider workflow](https://github.com/openpubkey/opkssh/actions/runs/23819884753/job/69429162670) started failing with:

```
main.go:315: undefined: GetLogFilePath
```

## Root Cause

The `Login` step in `gha.yml` uses `go run main.go login github --print-id-token`. 

The command `go run main.go` only compiles the **single file** `main.go`. It does **not** include other files in the `main` package such as `logpath_unix.go` and `logpath_windows.go` — which is where `GetLogFilePath()` is defined.

Before PR #480, this worked because `main.go` was self-contained (the log path was a hardcoded variable). After PR #480 moved the log path into platform-specific files with build constraints, `go run main.go` can no longer resolve the `GetLogFilePath` symbol.

## Fix

Change `go run main.go` to `go run .` which compiles **all** files in the current package directory, correctly including the platform-specific files and their build constraints.

## Testing

All CI workflows pass with this change (Build, CI, zizmor, Windows Server 2022, Windows Server 2025).