### PR TITLE
Update go version in hack/build.sh

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -6,7 +6,7 @@ set -eou pipefail
 
 pushd $SCRIPT_DIR/../
 
-GO_VERSION=${GO_VERSION:-"1.24.2"}
+GO_VERSION=${GO_VERSION:-"1.25.11"}
 
 mkdir -p .cache
 mkdir -p .mod-cache


### PR DESCRIPTION
Requiered go version is 1.25.0 but `build.sh`
still requests the old 1.24 version.