### PR TITLE
Adds ssh certificate principals arg

### DIFF
--- a/commands/login.go
+++ b/commands/login.go
@@ -234,14 +234,6 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 		}
 	}
 
-	if l.PrincipalsArg == nil {
-		// If principals field is empty sshd automatically rejects the SSH certificate.
-		// We use opkssh-wildcard as placeholder so that we can allow the OPK
-		// verifier to make this policy decision instead of sshd.
-		// See https://github.com/openpubkey/opkssh/pull/513
-		l.PrincipalsArg = []string{"opkssh-wildcard"}
-	}
-
 	// Execute login command
 	if l.AutoRefreshArg {
 		if providerRefreshable, ok := provider.(providers.RefreshableOpenIdProvider); ok {

--- a/commands/login.go
+++ b/commands/login.go
@@ -479,6 +479,14 @@ func (l *LoginCmd) login(ctx context.Context, provider providers.OpenIdProvider,
 		}
 	}
 
+	if l.PrincipalsArg == nil {
+		// If principals field is empty sshd automatically rejects the SSH certificate.
+		// We use opkssh-wildcard as placeholder so that we can allow the OPK
+		// verifier to make this policy decision instead of sshd.
+		// See https://github.com/openpubkey/opkssh/pull/513
+		l.PrincipalsArg = []string{"opkssh-wildcard"}
+	}
+
 	certBytes, seckeySshPem, err := createSSHCertWithAccessToken(pkt, accessToken, signer, l.PrincipalsArg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate SSH cert: %w", err)
@@ -528,10 +536,11 @@ func (l *LoginCmd) login(ctx context.Context, provider providers.OpenIdProvider,
 	fmt.Printf("Keys generated for identity\n%s\n", idStr)
 
 	return &LoginCmd{
-		pkt:    pkt,
-		signer: signer,
-		client: opkClient,
-		alg:    alg,
+		pkt:           pkt,
+		signer:        signer,
+		client:        opkClient,
+		alg:           alg,
+		PrincipalsArg: l.PrincipalsArg,
 	}, nil
 }
 

--- a/commands/login.go
+++ b/commands/login.go
@@ -98,17 +98,17 @@ type LoginCmd struct {
 	SSHConfigured         bool
 	Verbosity             int // Default verbosity is 0, 1 is verbose, 2 is debug
 	RemoteRedirectURI     string
+	PrincipalsArg         []string // The principals that will be included in the generated SSH cert. If not specified, it functions as a wildcard and will work for any principals.
 
 	overrideProvider *providers.OpenIdProvider // Used in tests to override the provider to inject a mock provider
 	// State
 	Config *config.ClientConfig
 
 	// Outputs
-	pkt        *pktoken.PKToken
-	signer     crypto.Signer
-	alg        jose.KeyAlgorithm
-	client     *client.OpkClient
-	principals []string
+	pkt    *pktoken.PKToken
+	signer crypto.Signer
+	alg    jose.KeyAlgorithm
+	client *client.OpkClient
 
 	// For testing
 	OutWriter io.Writer // Captures non-logged output that would normally be written to stdout
@@ -118,7 +118,7 @@ type LoginCmd struct {
 func NewLogin(autoRefreshArg bool, configPathArg string, createConfigArg bool, configureArg bool, logDirArg string,
 	sendAccessTokenArg bool, disableBrowserOpenArg bool, printIdTokenArg bool,
 	providerArg string, printKeyArg bool, keyPathArg string, providerAliasArg string, keyTypeArg KeyType,
-	remoteRedirectUri string, inspectCertArg bool,
+	remoteRedirectUri string, inspectCertArg bool, principalsArg []string,
 ) *LoginCmd {
 	return &LoginCmd{
 		Fs:                    afero.NewOsFs(),
@@ -137,6 +137,7 @@ func NewLogin(autoRefreshArg bool, configPathArg string, createConfigArg bool, c
 		ProviderAliasArg:      providerAliasArg,
 		KeyTypeArg:            keyTypeArg,
 		RemoteRedirectURI:     remoteRedirectUri,
+		PrincipalsArg:         principalsArg,
 	}
 }
 
@@ -231,6 +232,14 @@ func (l *LoginCmd) Run(ctx context.Context) error {
 		} else {
 			l.SendAccessTokenArg = opConfig.SendAccessToken
 		}
+	}
+
+	if l.PrincipalsArg == nil {
+		// If principals field is empty sshd automatically rejects the SSH certificate.
+		// We use opkssh-wildcard as placeholder so that we can allow the OPK
+		// verifier to make this policy decision instead of sshd.
+		// See https://github.com/openpubkey/opkssh/pull/513
+		l.PrincipalsArg = []string{"opkssh-wildcard"}
 	}
 
 	// Execute login command
@@ -478,12 +487,7 @@ func (l *LoginCmd) login(ctx context.Context, provider providers.OpenIdProvider,
 		}
 	}
 
-	// If principals field is empty sshd automatically rejects the SSH certificate.
-	// We use opkssh-wildcard as placeholder so that we can allow the OPK
-	// verifier to make this policy decision instead of sshd.
-	// See https://github.com/openpubkey/opkssh/pull/513
-	principals := []string{"opkssh-wildcard"}
-	certBytes, seckeySshPem, err := createSSHCertWithAccessToken(pkt, accessToken, signer, principals)
+	certBytes, seckeySshPem, err := createSSHCertWithAccessToken(pkt, accessToken, signer, l.PrincipalsArg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate SSH cert: %w", err)
 	}
@@ -532,11 +536,10 @@ func (l *LoginCmd) login(ctx context.Context, provider providers.OpenIdProvider,
 	fmt.Printf("Keys generated for identity\n%s\n", idStr)
 
 	return &LoginCmd{
-		pkt:        pkt,
-		signer:     signer,
-		client:     opkClient,
-		alg:        alg,
-		principals: principals,
+		pkt:    pkt,
+		signer: signer,
+		client: opkClient,
+		alg:    alg,
 	}, nil
 }
 
@@ -589,7 +592,7 @@ func (l *LoginCmd) LoginWithRefresh(ctx context.Context, provider providers.Refr
 				}
 			}
 
-			certBytes, seckeySshPem, err := createSSHCertWithAccessToken(loginResult.pkt, accessToken, loginResult.signer, loginResult.principals)
+			certBytes, seckeySshPem, err := createSSHCertWithAccessToken(loginResult.pkt, accessToken, loginResult.signer, loginResult.PrincipalsArg)
 			if err != nil {
 				return fmt.Errorf("failed to generate SSH cert: %w", err)
 			}

--- a/commands/login_test.go
+++ b/commands/login_test.go
@@ -156,6 +156,39 @@ func TestLoginCmd(t *testing.T) {
 			wantError: false,
 		},
 		{
+			name:    "Good path PrincipalsArg set to nil",
+			envVars: map[string]string{},
+			loginCmd: LoginCmd{
+				Verbosity:     0,
+				PrintKeyArg:   true,
+				LogDirArg:     logDir,
+				PrincipalsArg: nil,
+			},
+			wantError: false,
+		},
+		{
+			name:    "Good path PrincipalsArg set to empty",
+			envVars: map[string]string{},
+			loginCmd: LoginCmd{
+				Verbosity:     0,
+				PrintKeyArg:   true,
+				LogDirArg:     logDir,
+				PrincipalsArg: []string{},
+			},
+			wantError: false,
+		},
+		{
+			name:    "Good path PrincipalsArg set to specific principals",
+			envVars: map[string]string{},
+			loginCmd: LoginCmd{
+				Verbosity:     0,
+				PrintKeyArg:   true,
+				LogDirArg:     logDir,
+				PrincipalsArg: []string{"alice", "bob", "root"},
+			},
+			wantError: false,
+		},
+		{
 			name:    "Good path InspectCert",
 			envVars: map[string]string{},
 			loginCmd: LoginCmd{
@@ -275,6 +308,16 @@ func TestLoginCmd(t *testing.T) {
 					}
 					certSmug, err := sshcert.NewFromAuthorizedKey("fake-cert-type", string(pubKeyBytes))
 					require.NoError(t, err)
+
+					if tt.loginCmd.PrincipalsArg == nil {
+						// We use the wildcard principal when PrincipalsArg is nil
+						require.Equal(t, []string{"opkssh-wildcard"}, certSmug.SshCert.ValidPrincipals)
+					} else if len(tt.loginCmd.PrincipalsArg) == 0 {
+						// A list of length 0 gets deserialized as nil in an sshCert
+						require.Nil(t, certSmug.SshCert.ValidPrincipals)
+					} else {
+						require.Equal(t, tt.loginCmd.PrincipalsArg, certSmug.SshCert.ValidPrincipals)
+					}
 
 					accToken := certSmug.GetAccessToken()
 					if tt.wantAccessToken {
@@ -466,9 +509,10 @@ func TestNewLogin(t *testing.T) {
 	keyAsOutputArg := false
 	keyTypeArg := ECDSA
 	remoteRedirectURIArg := ""
+	var principalsDesired []string = nil
 
 	loginCmd := NewLogin(autoRefresh, configPathArg, createConfig, configureArg, logDir,
-		sendAccessTokenArg, disableBrowserOpenArg, printIdTokenArg, providerArg, keyAsOutputArg, keyPathArg, providerAlias, keyTypeArg, remoteRedirectURIArg, false)
+		sendAccessTokenArg, disableBrowserOpenArg, printIdTokenArg, providerArg, keyAsOutputArg, keyPathArg, providerAlias, keyTypeArg, remoteRedirectURIArg, false, principalsDesired)
 	require.NotNil(t, loginCmd)
 }
 

--- a/main.go
+++ b/main.go
@@ -158,6 +158,7 @@ Arguments:
 	var keyPathArg string
 	var keyTypeArg commands.KeyType
 	var remoteRedirectURIArg string
+	var principalsArg []string
 
 	loginCmd := &cobra.Command{
 		SilenceUsage: true,
@@ -195,7 +196,7 @@ Arguments:
 
 			login := commands.NewLogin(autoRefreshArg, configPathArg, createConfigArg, configureArg, logDirArg,
 				sendAccessTokenArg, disableBrowserOpenArg, printIdTokenArg, providerArg, printKeyArg, keyPathArg,
-				providerAliasArg, keyTypeArg, remoteRedirectURIArg, inspectCertArg)
+				providerAliasArg, keyTypeArg, remoteRedirectURIArg, inspectCertArg, principalsArg)
 			if err := login.Run(ctx); err != nil {
 				log.Println("Error executing login command:", err)
 				return err
@@ -221,6 +222,7 @@ Arguments:
 	loginCmd.Flags().StringVarP(&keyPathArg, "private-key-file", "i", "", "Path where private keys is written")
 	loginCmd.Flags().StringVar(&remoteRedirectURIArg, "remote-redirect-uri", "", "Remote redirect URI used for non-localhost redirects. This is an advanced option for embedding opkssh in server-side logic.")
 	loginCmd.Flags().VarP(enumflag.New(&keyTypeArg, "Key Type", map[commands.KeyType][]string{commands.ECDSA: {commands.ECDSA.String()}, commands.ED25519: {commands.ED25519.String()}}, enumflag.EnumCaseInsensitive), "key-type", "t", "Type of key to generate")
+	loginCmd.Flags().StringSliceVar(&principalsArg, "principals", nil, "Comma separated list of principals to include in the generated SSH certificate. If not specified it will work for any principal. Do not use unless you know what you are doing.")
 	rootCmd.AddCommand(loginCmd)
 
 	var logoutKeyPathArg string

--- a/sshcert/sshcert.go
+++ b/sshcert/sshcert.go
@@ -34,13 +34,6 @@ type SshCertSmuggler struct {
 }
 
 func New(pkt *pktoken.PKToken, accessToken []byte, principals []string) (*SshCertSmuggler, error) {
-	if principals == nil {
-		// If principals field is empty sshd automatically rejects the SSH certificate.
-		// We use opkssh-wildcard as placeholder so that we can allow the OPK
-		// verifier to make this policy decision instead of sshd.
-		// See https://github.com/openpubkey/opkssh/pull/513
-		principals = []string{"opkssh-wildcard"}
-	}
 
 	// TODO: assumes email exists in ID Token,
 	// this will break for OPs like Azure that do not have email as a claim

--- a/sshcert/sshcert.go
+++ b/sshcert/sshcert.go
@@ -34,6 +34,13 @@ type SshCertSmuggler struct {
 }
 
 func New(pkt *pktoken.PKToken, accessToken []byte, principals []string) (*SshCertSmuggler, error) {
+	if principals == nil {
+		// If principals field is empty sshd automatically rejects the SSH certificate.
+		// We use opkssh-wildcard as placeholder so that we can allow the OPK
+		// verifier to make this policy decision instead of sshd.
+		// See https://github.com/openpubkey/opkssh/pull/513
+		principals = []string{"opkssh-wildcard"}
+	}
 
 	// TODO: assumes email exists in ID Token,
 	// this will break for OPs like Azure that do not have email as a claim


### PR DESCRIPTION
See bug in https://github.com/openpubkey/opkssh/issues/522#issuecomment-4583399739 where an upgraded client provides ssh certs that will be rejected by an older server because the updated client sets an principal in the ssh cert.

| OPKSSH Client | OPKSSH Server | OpenSSH Server | Result | Notes |
| :--- | :--- | :--- | :--- | :--- |
| Older than v0.14 | Older than v0.14 | Older than 10.3 | ✅ Success | |
| Older than v0.14 | v0.14 or newer | Older than 10.3 | ✅ Success | |
| v0.14 or newer | Older than v0.14 | Older than 10.3 | ❌ Failure |  **BUG TRIGGERS HERE** |
| v0.14 or newer | v0.14 or newer | Older than 10.3 | ✅ Success | |
| Older than v0.14 | Older than v0.14 | 10.3 or newer | ❌ Failure | OpenSSH 10.3+ breaks legacy OPKSSH |
| Older than v0.14 | v0.14 or newer | 10.3 or newer | ❌ Failure | OpenSSH 10.3+ breaks legacy OPKSSH |
| v0.14 or newer | Older than v0.14 | 10.3 or newer | ❌ Failure | OpenSSH 10.3+ breaks legacy OPKSSH |
| v0.14 or newer | v0.14 or newer | 10.3 or newer | ✅ Success | Meet 10.3+ requirements |

This fixes https://github.com/openpubkey/opkssh/issues/522 by providing an principals arg to `opkssh login`  Additionally we might want to add an arg to `opkssh login` to specify what the valid principals in the cert should be.  This is a potentially useful configuration parameter.

Manually tested against opkssh 0.12.0 replicating the failure to connect when ` .\opkssh.exe login` is used, but ` .\opkssh.exe login -principals=` works.

<img width="1113" height="314" alt="image" src="https://github.com/user-attachments/assets/97543864-f45e-4332-aaf3-9419f65f152a" />


