### PR TITLE
Fix release drafter

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -32,27 +32,3 @@ template: |
   ## Changes
 
   $CHANGES
-
-autolabeler:
-  - label: "chore"
-    files:
-      - "*.md"
-    branch:
-      - '/docs{0,1}\/.+/'
-      - '/tests{0,1}\/.+/'
-    title:
-      - "/docs/i"
-      - "/test/i"
-  - label: "bug"
-    branch:
-      - '/fix\/.+/'
-      - '/revert\/.+/'
-    title:
-      - "/fix/i"
-      - "/revert/i"
-  - label: "feature"
-    branch:
-      - '/feature\/.+/'
-      - '/feat\/.+/'
-    title:
-      - "/feat/i"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, reopened, synchronize]
 permissions:
   contents: read
 


### PR DESCRIPTION
release drafter doesn't have permissions for autolabeling PRs when running on PRs. This was causing build failures. I don't fully understand the security implications of giving this access to PR triggered jobs and even if I did, why is it worth the risk that I accidently overprivileged something? For this reason I am removing autolabeling from the release drafter.