### PR TITLE
Update to OpenPubkey v0.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/lestrrat-go/jwx/v3 v3.0.12
 	github.com/melbahja/goph v1.4.0
-	github.com/openpubkey/openpubkey v0.23.0
+	github.com/openpubkey/openpubkey v0.25.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.38.0

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/openpubkey/openpubkey v0.23.0 h1:E4CaQnMH6Fwk83Rk22WIObYmlZf9kKM2ZZWGvxY/t9I=
-github.com/openpubkey/openpubkey v0.23.0/go.mod h1:mxb80p5GTrKF+s/HluHFWlzG3GTHBC1eO+g2n8maG+E=
+github.com/openpubkey/openpubkey v0.25.0 h1:+jsbjc3HJ1RO6Qchd7NeZCg1gqF4MfYd/vPhY1abnXY=
+github.com/openpubkey/openpubkey v0.25.0/go.mod h1:0vU6vBgZxzzCiAPOmbae6Md2VIjx+8WzOnrD4bL0D2o=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.5/go.mod h1:wHDZ0IZX6JcBYRK1TH9bcVq8G7TLpVHYIGJRFnmPfxg=


### PR DESCRIPTION
OpenPubkey had a security issue in the GQ binding for GitLab, we should move to the newest version of OpenPubkey 

See details here https://github.com/openpubkey/openpubkey/pull/379