### PR TITLE
Deny malformed oidc policy rows instead of panicking

### DIFF
--- a/policy/enforcer.go
+++ b/policy/enforcer.go
@@ -136,6 +136,13 @@ func validateClaim(claims *checkedClaims, user *User) bool {
 	// Should we match on an oidc claim?
 	if strings.HasPrefix(user.IdentityAttribute, OIDC_CLAIMS) {
 		oidcGroupSections := EscapedSplit(user.IdentityAttribute, ':')
+		// A well formed row is oidc:<claim>:<value>. EscapedSplit drops empty
+		// fields, so "oidc:" and "oidc::" come back as a single section and
+		// indexing into them panics. Treat a short row as no match.
+		if len(oidcGroupSections) < 3 {
+			log.Printf("warning: malformed oidc identity attribute %q in policy, expected oidc:<claim>:<value>", user.IdentityAttribute)
+			return false
+		}
 		oidcGroupsName := strings.Trim(oidcGroupSections[1], "\"")
 
 		return slices.Contains(

--- a/policy/enforcer_test.go
+++ b/policy/enforcer_test.go
@@ -426,6 +426,36 @@ func TestPolicyDeniedMissingOidcGroupsClaim(t *testing.T) {
 	require.Error(t, err, "user should not as the token is missing the groups claim")
 }
 
+func TestPolicyDeniedMalformedOidcRow(t *testing.T) {
+	t.Parallel()
+
+	op := NewMockOpenIdProviderGroups(t, "groups", []string{"a", "b", "c"})
+
+	opkClient, err := client.New(op)
+	require.NoError(t, err)
+	pkt, err := opkClient.Auth(context.Background())
+	require.NoError(t, err)
+
+	// EscapedSplit drops empty fields, so these rows used to produce a
+	// single section and panic on oidcGroupSections[1].
+	for _, identityAttribute := range []string{"oidc:", "oidc::", "oidc:::"} {
+		policyEnforcer := &policy.Enforcer{
+			PolicyLoader: &MockPolicyLoader{Policy: &policy.Policy{
+				Users: []policy.User{
+					{
+						IdentityAttribute: identityAttribute,
+						Principals:        []string{"test"},
+						Issuer:            "https://accounts.example.com",
+					},
+				},
+			}},
+		}
+
+		err = policyEnforcer.CheckPolicy("test", pkt, "", "example-base64Cert", "ssh-rsa", policy.DenyList{}, nil)
+		require.Error(t, err, "malformed row %q should deny, not panic", identityAttribute)
+	}
+}
+
 func TestEnforcerTableTest(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #587. Picking this up after your email, since you are busy this week.

`EscapedSplit` drops empty fields, so a policy row whose identity attribute is exactly `oidc:` or `oidc::` splits into one section and `oidcGroupSections[1]` panics with index out of range. Nothing recovers on that path, so `opkssh verify` crashes and the login is denied by the crash rather than by policy, which is the thing the docs say a bad row should not do.

The patch requires the documented `oidc:<claim>:<value>` shape, logs the malformed row, and returns no match. Quoted claim names still work, since `oidc:"https://acme.com/groups":e` splits into three sections.

Test is `TestPolicyDeniedMalformedOidcRow`, driving the real `CheckPolicy` with `oidc:`, `oidc::` and `oidc:::`. On main it dies with:

```
panic: runtime error: index out of range [1] with length 1
```

With the patch all three deny cleanly and `go test ./policy/` passes.