### PR TITLE
Warn when a policy row matches on an unverified email

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -133,6 +133,8 @@ We support email "wildcard" validation using the `oidc-match-end:email:` prefix.
 - This matching is **case-insensitive**.
 - Use with care, as allowing a domain grants access to all users at that domain.
 
+Matching on email trusts the OpenID Provider to be authoritative for that email address. opkssh does not require `email_verified` to be true, because an OP that is authoritative for a domain may leave the claim out or set it to false and still be the right source of truth. When a policy row matches on email and the ID Token does not assert `email_verified`, opkssh logs a warning. If you do not trust an OP as an authoritative source for email, match on `sub` instead, or enforce your own rule with a [policy plugin](policyplugins.md).
+
 ### System authorized identity file `/etc/opk/auth_id` (Linux) or `%ProgramData%\opk\auth_id` (Windows)
 
 This is a server wide policy file.

--- a/policy/enforcer.go
+++ b/policy/enforcer.go
@@ -34,6 +34,10 @@ import (
 const (
 	OIDC_CLAIMS         = "oidc:"
 	OIDC_WILDCARD_EMAIL = "oidc-match-end:email:"
+
+	// EMAIL_VERIFIED_CLAIM is read out of ExtraClaims, where a bool and a
+	// string value both end up normalized to a string.
+	EMAIL_VERIFIED_CLAIM = "email_verified"
 )
 
 // DenyList represents the DenyLists in the server config
@@ -50,12 +54,9 @@ type Enforcer struct {
 
 // type for Identity Token checkedClaims
 type checkedClaims struct {
-	Email string `json:"email"`
-	// EmailVerified is a pointer so we can tell "claim absent" from
-	// "claim present and false". Not all OPs send it.
-	EmailVerified *bool               `json:"email_verified"`
-	Sub           string              `json:"sub"`
-	ExtraClaims   map[string][]string `json:"-"`
+	Email       string              `json:"email"`
+	Sub         string              `json:"sub"`
+	ExtraClaims map[string][]string `json:"-"`
 }
 
 func (s *checkedClaims) UnmarshalJSON(data []byte) error {
@@ -188,12 +189,18 @@ func validateClaim(claims *checkedClaims, user *User) bool {
 // warnIfEmailUnverified logs when a policy row matched on the email claim but
 // the ID Token does not assert that the email was verified. Admins who want
 // this enforced rather than logged should match on sub or use a policy plugin.
+//
+// The value is read from ExtraClaims rather than a typed struct field because
+// some OPs send email_verified as the string "true" rather than a bool, and
+// unmarshalling that into a bool would fail the whole token. ExtraClaims
+// normalizes both shapes to a string.
 func warnIfEmailUnverified(claims *checkedClaims, identityAttribute string) {
+	values, ok := claims.ExtraClaims[EMAIL_VERIFIED_CLAIM]
 	switch {
-	case claims.EmailVerified == nil:
+	case !ok || len(values) == 0:
 		log.Printf("warning: policy %q matched on email %q but the ID Token has no email_verified claim, consider matching on sub instead", identityAttribute, claims.Email)
-	case !*claims.EmailVerified:
-		log.Printf("warning: policy %q matched on email %q but the ID Token sets email_verified to false, consider matching on sub instead", identityAttribute, claims.Email)
+	case !strings.EqualFold(values[0], "true"):
+		log.Printf("warning: policy %q matched on email %q but the ID Token sets email_verified to %q, consider matching on sub instead", identityAttribute, claims.Email, values[0])
 	}
 }
 

--- a/policy/enforcer.go
+++ b/policy/enforcer.go
@@ -50,9 +50,12 @@ type Enforcer struct {
 
 // type for Identity Token checkedClaims
 type checkedClaims struct {
-	Email       string              `json:"email"`
-	Sub         string              `json:"sub"`
-	ExtraClaims map[string][]string `json:"-"`
+	Email string `json:"email"`
+	// EmailVerified is a pointer so we can tell "claim absent" from
+	// "claim present and false". Not all OPs send it.
+	EmailVerified *bool               `json:"email_verified"`
+	Sub           string              `json:"sub"`
+	ExtraClaims   map[string][]string `json:"-"`
 }
 
 func (s *checkedClaims) UnmarshalJSON(data []byte) error {
@@ -163,7 +166,28 @@ func validateClaim(claims *checkedClaims, user *User) bool {
 
 	// email should be a case-insensitive check
 	// sub should be a case-sensitive check
-	return wildCardEmailMatch || strings.EqualFold(claims.Email, user.IdentityAttribute) || string(claims.Sub) == user.IdentityAttribute
+	emailMatch := wildCardEmailMatch || strings.EqualFold(claims.Email, user.IdentityAttribute)
+	if emailMatch {
+		// We still allow the match. An OP that is authoritative for a domain
+		// may leave email_verified out, or set it to false, and still be the
+		// right source of truth for that email, so this is the admin's call.
+		// Surface it so the choice is visible.
+		warnIfEmailUnverified(claims, user.IdentityAttribute)
+	}
+
+	return emailMatch || string(claims.Sub) == user.IdentityAttribute
+}
+
+// warnIfEmailUnverified logs when a policy row matched on the email claim but
+// the ID Token does not assert that the email was verified. Admins who want
+// this enforced rather than logged should match on sub or use a policy plugin.
+func warnIfEmailUnverified(claims *checkedClaims, identityAttribute string) {
+	switch {
+	case claims.EmailVerified == nil:
+		log.Printf("warning: policy %q matched on email %q but the ID Token has no email_verified claim, consider matching on sub instead", identityAttribute, claims.Email)
+	case !*claims.EmailVerified:
+		log.Printf("warning: policy %q matched on email %q but the ID Token sets email_verified to false, consider matching on sub instead", identityAttribute, claims.Email)
+	}
 }
 
 // CheckPolicy loads opkssh policy and checks to see if there is a policy

--- a/policy/enforcer_test.go
+++ b/policy/enforcer_test.go
@@ -445,14 +445,19 @@ func NewMockOpenIdProviderEmailVerified(t *testing.T, emailVerified any) provide
 // A policy row matching on email should still be allowed when the ID Token
 // does not assert email_verified, but the admin should see a warning.
 func TestEmailVerifiedWarning(t *testing.T) {
+	// Some OPs send email_verified as a string rather than a bool, so both
+	// shapes have to be handled. See oauth2-proxy/oauth2-proxy#629.
 	tests := []struct {
 		name          string
 		emailVerified any
 		wantWarning   string
 	}{
 		{name: "claim absent", emailVerified: nil, wantWarning: "no email_verified claim"},
-		{name: "claim false", emailVerified: false, wantWarning: "email_verified to false"},
-		{name: "claim true", emailVerified: true, wantWarning: ""},
+		{name: "bool false", emailVerified: false, wantWarning: `email_verified to "false"`},
+		{name: "bool true", emailVerified: true, wantWarning: ""},
+		{name: "string false", emailVerified: "false", wantWarning: `email_verified to "false"`},
+		{name: "string true", emailVerified: "true", wantWarning: ""},
+		{name: "string True", emailVerified: "True", wantWarning: ""},
 	}
 
 	for _, tt := range tests {
@@ -475,7 +480,7 @@ func TestEmailVerifiedWarning(t *testing.T) {
 			require.NoError(t, err, "email match should still be allowed")
 
 			if tt.wantWarning == "" {
-				require.NotContains(t, logs.String(), "email_verified")
+				require.NotContains(t, logs.String(), "consider matching on sub")
 			} else {
 				require.Contains(t, logs.String(), tt.wantWarning)
 			}
@@ -509,7 +514,7 @@ func TestEmailVerifiedNoWarningOnSubMatch(t *testing.T) {
 
 	err = policyEnforcer.CheckPolicy("test", pkt, "", "example-base64Cert", "ssh-rsa", policy.DenyList{}, nil)
 	require.NoError(t, err)
-	require.False(t, strings.Contains(logs.String(), "email_verified"))
+	require.False(t, strings.Contains(logs.String(), "consider matching on sub"))
 }
 
 func TestPolicyDeniedMalformedOidcRow(t *testing.T) {

--- a/policy/enforcer_test.go
+++ b/policy/enforcer_test.go
@@ -17,8 +17,12 @@
 package policy_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/openpubkey/openpubkey/client"
@@ -424,6 +428,88 @@ func TestPolicyDeniedMissingOidcGroupsClaim(t *testing.T) {
 
 	err = policyEnforcer.CheckPolicy("test", pkt, "", "example-base64Cert", "ssh-rsa", policy.DenyList{}, nil)
 	require.Error(t, err, "user should not as the token is missing the groups claim")
+}
+
+func NewMockOpenIdProviderEmailVerified(t *testing.T, emailVerified any) providers.OpenIdProvider {
+	providerOpts := providers.DefaultMockProviderOpts()
+	op, _, idTokenTemplate, err := providers.NewMockProvider(providerOpts)
+	require.NoError(t, err)
+	extraClaims := map[string]any{"email": "arthur.aardvark@example.com"}
+	if emailVerified != nil {
+		extraClaims["email_verified"] = emailVerified
+	}
+	idTokenTemplate.ExtraClaims = extraClaims
+	return op
+}
+
+// A policy row matching on email should still be allowed when the ID Token
+// does not assert email_verified, but the admin should see a warning.
+func TestEmailVerifiedWarning(t *testing.T) {
+	tests := []struct {
+		name          string
+		emailVerified any
+		wantWarning   string
+	}{
+		{name: "claim absent", emailVerified: nil, wantWarning: "no email_verified claim"},
+		{name: "claim false", emailVerified: false, wantWarning: "email_verified to false"},
+		{name: "claim true", emailVerified: true, wantWarning: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			op := NewMockOpenIdProviderEmailVerified(t, tt.emailVerified)
+			opkClient, err := client.New(op)
+			require.NoError(t, err)
+			pkt, err := opkClient.Auth(context.Background())
+			require.NoError(t, err)
+
+			policyEnforcer := &policy.Enforcer{
+				PolicyLoader: &MockPolicyLoader{Policy: policyTest},
+			}
+
+			var logs bytes.Buffer
+			log.SetOutput(&logs)
+			defer log.SetOutput(os.Stderr)
+
+			err = policyEnforcer.CheckPolicy("test", pkt, "", "example-base64Cert", "ssh-rsa", policy.DenyList{}, nil)
+			require.NoError(t, err, "email match should still be allowed")
+
+			if tt.wantWarning == "" {
+				require.NotContains(t, logs.String(), "email_verified")
+			} else {
+				require.Contains(t, logs.String(), tt.wantWarning)
+			}
+		})
+	}
+}
+
+// Matching on sub should not produce an email_verified warning.
+func TestEmailVerifiedNoWarningOnSubMatch(t *testing.T) {
+	op := NewMockOpenIdSubProvider(t, "repo:organization/repository:ref:refs/heads/main")
+	opkClient, err := client.New(op)
+	require.NoError(t, err)
+	pkt, err := opkClient.Auth(context.Background())
+	require.NoError(t, err)
+
+	policyEnforcer := &policy.Enforcer{
+		PolicyLoader: &MockPolicyLoader{Policy: &policy.Policy{
+			Users: []policy.User{
+				{
+					IdentityAttribute: "repo:organization/repository:ref:refs/heads/main",
+					Principals:        []string{"test"},
+					Issuer:            "https://accounts.example.com",
+				},
+			},
+		}},
+	}
+
+	var logs bytes.Buffer
+	log.SetOutput(&logs)
+	defer log.SetOutput(os.Stderr)
+
+	err = policyEnforcer.CheckPolicy("test", pkt, "", "example-base64Cert", "ssh-rsa", policy.DenyList{}, nil)
+	require.NoError(t, err)
+	require.False(t, strings.Contains(logs.String(), "email_verified"))
 }
 
 func TestEnforcerTableTest(t *testing.T) {


### PR DESCRIPTION
Fixes #591, taking the second one off your plate since you are busy this week.

This follows the shape you laid out in the issue rather than my original suggestion. Nothing is denied that was allowed before. When a policy row matches on the email claim (exact or `oidc-match-end:email:`) and the ID Token either has no `email_verified` claim or sets it to false, opkssh allows the login and logs a warning. `email_verified: true` and `sub` matches log nothing.

`checkedClaims.EmailVerified` is a `*bool` so an absent claim is distinguishable from a present false one, and the two cases get different warning text.

I left out any config knob. Your note said admins who want this enforced should use a plugin, and a knob is easy to layer on later if you decide you want one.

Also added a short paragraph to docs/config.md next to the email matching section: matching on email trusts the OP to be authoritative for it, opkssh warns rather than enforces, and if you do not trust an OP for email use `sub` or a plugin.

Tests: `TestEmailVerifiedWarning` covers claim absent, false and true, asserting both that access is still granted and what does or does not get logged. `TestEmailVerifiedNoWarningOnSubMatch` pins that a sub match stays quiet. The absent and false cases fail on main. `go test ./...` passes.