### PR TITLE
fix: Policy footguns

### DIFF
--- a/policy/enforcer.go
+++ b/policy/enforcer.go
@@ -34,6 +34,7 @@ import (
 const (
 	OIDC_CLAIMS         = "oidc:"
 	OIDC_WILDCARD_EMAIL = "oidc-match-end:email:"
+	REPO_CLAIM          = "repo:"
 
 	// EMAIL_VERIFIED_CLAIM is read out of ExtraClaims, where a bool and a
 	// string value both end up normalized to a string.
@@ -136,6 +137,13 @@ func validateClaim(claims *checkedClaims, user *User) bool {
 	if strings.HasPrefix(claims.Email, OIDC_WILDCARD_EMAIL) {
 		return false
 	}
+	if strings.EqualFold(user.IdentityAttribute, OIDC_WILDCARD_EMAIL) ||
+		strings.EqualFold(user.IdentityAttribute, OIDC_CLAIMS) ||
+		strings.EqualFold(user.IdentityAttribute, REPO_CLAIM) {
+		// If the policy is set to match any value, this is unsafe and we should fail
+		log.Printf("error: rejecting unsafe match - policy (%q) matches any value:", user.IdentityAttribute)
+		return false
+	}
 
 	// Should we match on an oidc claim?
 	if strings.HasPrefix(user.IdentityAttribute, OIDC_CLAIMS) {
@@ -164,7 +172,7 @@ func validateClaim(claims *checkedClaims, user *User) bool {
 	}
 
 	// Should we match on a glob pattern for the sub claim?
-	if strings.HasPrefix(user.IdentityAttribute, "repo:") {
+	if strings.HasPrefix(user.IdentityAttribute, REPO_CLAIM) {
 		if matched, err := path.Match(user.IdentityAttribute, string(claims.Sub)); err != nil {
 			log.Printf("warning: invalid glob pattern %q in policy: %v", user.IdentityAttribute, err)
 		} else if matched {

--- a/policy/enforcer_test.go
+++ b/policy/enforcer_test.go
@@ -647,6 +647,22 @@ func TestEnforcerTableTest(t *testing.T) {
 			policyLoader:  &MockPolicyLoader{Error: fmt.Errorf("error loading policy")},
 			expectedError: "error loading policy",
 		},
+		{
+			name: "policy email wildcard rejects policies that allow any value",
+			op:   NewMockOpenIdProvider(t),
+			policyLoader: &MockPolicyLoader{
+				Policy: &policy.Policy{
+					[]policy.User{
+						{
+							IdentityAttribute: "oidc-match-end:email:",
+							Issuer:            "https://accounts.example.com",
+							Principals:        []string{"test"},
+						},
+					},
+				},
+			},
+			expectedError: `no policy to allow arthur.aardvark@example.com with (issuer=https://accounts.example.com) to assume test`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
For policies like `oidc-match-end:email:` which don't specify any value to match on. This results in it matching on any value. Policies that match on any value are not safe and we should reject any such matches. This PR rejects these matches.


Fixes https://github.com/openpubkey/opkssh/issues/589