### PR TITLE
policy/plugins: marshal GROUPS and AUD env JSON with encoding/json

### DIFF
--- a/policy/plugins/tokens.go
+++ b/policy/plugins/tokens.go
@@ -62,7 +62,11 @@ func PopulatePluginEnvVars(pkt *pktoken.PKToken, userInfoJson string, principal 
 
 	groupsStr := ""
 	if claims.Groups != nil {
-		groupsStr = fmt.Sprintf(`["%s"]`, strings.Join(*claims.Groups, `","`))
+		groupsJSON, err := json.Marshal(*claims.Groups)
+		if err != nil {
+			return nil, fmt.Errorf("error marshalling groups claim: %w", err)
+		}
+		groupsStr = string(groupsJSON)
 	}
 
 	emailVerifiedStr := string(claims.EmailVerified)
@@ -152,7 +156,11 @@ type Audience string
 func (a *Audience) UnmarshalJSON(data []byte) error {
 	var multi []string
 	if err := json.Unmarshal(data, &multi); err == nil {
-		*a = Audience(`["` + strings.Join(multi, `","`) + `"]`)
+		audJSON, err := json.Marshal(multi)
+		if err != nil {
+			return err
+		}
+		*a = Audience(string(audJSON))
 		return nil
 	}
 

--- a/policy/plugins/tokens_test.go
+++ b/policy/plugins/tokens_test.go
@@ -18,6 +18,7 @@ package plugins
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -26,6 +27,14 @@ import (
 	"github.com/openpubkey/openpubkey/providers"
 	"github.com/stretchr/testify/require"
 )
+
+// roundTripJSONArray asserts env JSON parses back to exactly want.
+func roundTripJSONArray(t *testing.T, got string, want []string) {
+	t.Helper()
+	var parsed []string
+	require.NoError(t, json.Unmarshal([]byte(got), &parsed))
+	require.Equal(t, want, parsed)
+}
 
 func CreateMockPKToken(t *testing.T, claims map[string]any) *pktoken.PKToken {
 	providerOpts := providers.DefaultMockProviderOpts()
@@ -267,4 +276,31 @@ func TestNewTokens(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPluginEnvJSONEscapesSpecialChars(t *testing.T) {
+	groups := []string{`x","ssh-admins`, `a\b`}
+	pkt := CreateMockPKToken(t, map[string]any{
+		"groups": groups,
+		"iat":    1999999990,
+	})
+	tokens, err := PopulatePluginEnvVars(pkt, "", "root", b64("SSH certificate"), "ssh-rsa", nil)
+	require.NoError(t, err)
+	roundTripJSONArray(t, tokens["OPKSSH_PLUGIN_GROUPS"], groups)
+}
+
+func TestAudienceUnmarshalJSONEscapesSpecialChars(t *testing.T) {
+	raw := []byte(`["client\",\"injected","other"]`)
+	// Simulate IdP multi-aud claim values that contain quote/backslash metacharacters.
+	input, err := json.Marshal([]string{`client","injected`, `a\b`, "other"})
+	require.NoError(t, err)
+
+	var aud Audience
+	require.NoError(t, aud.UnmarshalJSON(input))
+	roundTripJSONArray(t, string(aud), []string{`client","injected`, `a\b`, "other"})
+
+	// Control: already-escaped JSON array still unmarshals cleanly.
+	var aud2 Audience
+	require.NoError(t, aud2.UnmarshalJSON(raw))
+	roundTripJSONArray(t, string(aud2), []string{`client","injected`, "other"})
 }


### PR DESCRIPTION
## Summary

`OPKSSH_PLUGIN_GROUPS` and multi-value `OPKSSH_PLUGIN_AUD` were built with string concatenation (`fmt.Sprintf` / `strings.Join`) instead of `json.Marshal`. A claim value containing a double quote or backslash could break out of its JSON string element, so a policy plugin that parses these env vars as JSON could see fabricated list members (or reject malformed JSON).

This PR switches both call sites to `encoding/json` so values are escaped correctly, matching how `OPKSSH_PLUGIN_EXTRA_ARGS` is already built.

## Test plan

- [x] `go test ./policy/plugins/` (includes round-trip coverage for quote/backslash in groups and multi-aud)
- [x] Existing tokens table tests still pass for plain groups and multi-aud

DCO: Signed-off-by on the commit. Tooling credit for local prep only; commit identity is Sasha Mitchell.

Made with [Cursor](https://cursor.com)