### PR TITLE
Support sshd_session_t SELinux domain in installer

### DIFF
--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -500,6 +500,29 @@ install_opkssh_binary() {
     fi
 }
 
+# install_selinux_module
+#   Compiles, packages, and loads an SELinux module from a TE file. Errors
+#   from the individual tools are suppressed so callers can silently try
+#   another TE variant on failure.
+#
+# Arguments:
+#   $1 - Path to the .te file
+#   $2 - Path to write the compiled module to
+#   $3 - Path to write the packaged module to
+#
+# Returns:
+#   0 if the module was compiled, packaged, and loaded successfully, 1 otherwise
+install_selinux_module() {
+    local te_file mod_out pp_out
+    te_file="$1"
+    mod_out="$2"
+    pp_out="$3"
+
+    checkmodule -M -m -o "$mod_out" "$te_file" >/dev/null 2>&1 &&
+        semodule_package -o "$pp_out" -m "$mod_out" >/dev/null 2>&1 &&
+        semodule -i "$pp_out" >/dev/null 2>&1
+}
+
 # check_selinux
 #   Checks if SELinux is enabled and if so, ensures the context is set correctly
 #
@@ -509,8 +532,9 @@ install_opkssh_binary() {
 # Returns:
 #   0 if SELinux is disabled or if context is correctly
 check_selinux() {
-    local te_tmp mod_tmp pp_tmp version
+    local te_tmp te_session_tmp mod_tmp pp_tmp version use_session_variant
     te_tmp="/tmp/opkssh.te"
+    te_session_tmp="/tmp/opkssh.session.te"
     mod_tmp="/tmp/opkssh.mod" # SELinux requires that modules have the same file name as the module name
     pp_tmp="/tmp/opkssh.pp"
 
@@ -520,6 +544,7 @@ check_selinux() {
             echo "  Restoring context for $INSTALL_DIR/$BINARY_NAME..."
             restorecon "$INSTALL_DIR/$BINARY_NAME"
 
+            use_session_variant=false
             if [[ -n "$LOCAL_TE_FILE" ]]; then
                 echo "  Using local TE-file"
                 cp "$LOCAL_TE_FILE" "$te_tmp"
@@ -531,16 +556,32 @@ check_selinux() {
                 fi
                 echo "  Downloading TE-file"
                 wget -q -O "$te_tmp" "https://raw.githubusercontent.com/${GITHUB_REPO}/refs/tags/${version}/opkssh.te"
+                use_session_variant=true
             fi
 
             echo "  Compiling SELinux module..."
-            checkmodule -M -m -o "$mod_tmp" "$te_tmp"
-
-            echo "  Packaging module..."
-            semodule_package -o "$pp_tmp" -m "$mod_tmp"
-
-            echo "  Installing module..."
-            semodule -i "$pp_tmp"
+            if [[ "$use_session_variant" == true ]]; then
+                # Some policies run AuthorizedKeysCommand in sshd_session_t,
+                # not sshd_t. Try that first; if the loaded policy lacks the
+                # type, the module fails to load and we fall back to sshd_t.
+                sed 's/sshd_t/sshd_session_t/g' "$te_tmp" > "$te_session_tmp"
+                if install_selinux_module "$te_session_tmp" "$mod_tmp" "$pp_tmp"; then
+                    echo "  Installed module for sshd_session_t"
+                elif install_selinux_module "$te_tmp" "$mod_tmp" "$pp_tmp"; then
+                    echo "  Installed module for sshd_t"
+                else
+                    rm -f "$te_tmp" "$te_session_tmp" "$mod_tmp" "$pp_tmp"
+                    echo "Failed to compile/install the opkssh SELinux module" >&2
+                    return 1
+                fi
+                rm -f "$te_session_tmp"
+            else
+                if ! install_selinux_module "$te_tmp" "$mod_tmp" "$pp_tmp"; then
+                    rm -f "$te_tmp" "$mod_tmp" "$pp_tmp"
+                    echo "Failed to compile/install the opkssh SELinux module" >&2
+                    return 1
+                fi
+            fi
 
             rm -f "$te_tmp" "$mod_tmp" "$pp_tmp"
             if [[ "$HOME_POLICY" == true ]]; then

--- a/scripts/test/install-linux_test_check_selinux.sh
+++ b/scripts/test/install-linux_test_check_selinux.sh
@@ -19,6 +19,10 @@ setUp() {
     export HOME_POLICY SELINUX_ENABLE_SQUID SELINUX_ENABLE_PROXY
 
     DUMMY_TE_CONTENT="module dummy 1.0; require { type sshd_t; }; allow sshd_t self:process { transition };"
+
+    # Default: legacy policy, no sshd_session_t type.
+    mock_session_domain_unsupported=true
+    mock_checkmodule_fail=false
 }
 
 tearDown() {
@@ -49,7 +53,12 @@ getenforce() {
 
 checkmodule() {
     echo "checkmodule $*" >> "$MOCK_LOG"
-    /usr/bin/cat "$TE_TMP" >> "$MOCK_LOG"
+    # Last argument is the TE file being compiled.
+    local te_file="${!#}"
+    LAST_TE_FILE_CONTENT=$(cat "$te_file" 2>/dev/null)
+    echo "$LAST_TE_FILE_CONTENT" >> "$MOCK_LOG"
+    $mock_checkmodule_fail && return 1
+    return 0
 }
 
 restorecon() {
@@ -62,6 +71,12 @@ semodule_package() {
 
 semodule() {
     echo "semodule $*" >> "$MOCK_LOG"
+    # Simulate a load-time failure when the module requires a type the
+    # target's loaded policy does not define.
+    if [[ "$mock_session_domain_unsupported" == true && "$LAST_TE_FILE_CONTENT" == *"sshd_session_t"* ]]; then
+        return 1
+    fi
+    return 0
 }
 
 setsebool() {

--- a/test/integration/selinux_test.go
+++ b/test/integration/selinux_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 OpenPubkey
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/openpubkey/opkssh/internal/projectpath"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+)
+
+type selinuxPolicyTest struct {
+	name               string
+	image              string
+	expectedPolicyType string
+}
+
+// TestSELinuxPolicyInstallation verifies that the installer generates a
+// loadable policy module for both SSH daemon domains used by supported
+// SELinux policies. The containers do not need SELinux enforcing on the host:
+// semodule validates and links the module against each container's policy
+// store.
+func TestSELinuxPolicyInstallation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Docker-based integration tests are not supported on Windows")
+	}
+	if osType := os.Getenv("OS_TYPE"); osType != "" && osType != "centos" {
+		t.Skip("SELinux policy compatibility is covered by the CentOS integration job")
+	}
+
+	tests := []selinuxPolicyTest{
+		{
+			name:               "CentOS Stream 9 sshd_t",
+			image:              "quay.io/centos/centos:stream9",
+			expectedPolicyType: "sshd_t",
+		},
+		{
+			name:               "CentOS Stream 10 sshd_session_t",
+			image:              "quay.io/centos/centos:stream10",
+			expectedPolicyType: "sshd_session_t",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testSELinuxPolicyInstallation(t, tt)
+		})
+	}
+}
+
+func testSELinuxPolicyInstallation(t *testing.T, tt selinuxPolicyTest) {
+	ctx := context.Background()
+	req := testcontainers.ContainerRequest{
+		Image:      tt.image,
+		Cmd:        []string{"sleep", "infinity"},
+		AutoRemove: true,
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.NoError(t, err, "start SELinux test container")
+	t.Cleanup(func() {
+		if termErr := container.Terminate(ctx); termErr != nil {
+			t.Logf("Warning: failed to terminate SELinux test container: %v", termErr)
+		}
+	})
+
+	runSELinuxContainerCommand(t, container, "dnf install -y checkpolicy policycoreutils selinux-policy-devel")
+
+	for _, source := range []string{"opkssh.te", "scripts/install-linux.sh"} {
+		err := container.CopyFileToContainer(
+			ctx,
+			filepath.Join(projectpath.Root, source),
+			"/app/"+filepath.Base(source),
+			0o644,
+		)
+		require.NoError(t, err, "copy %s into container", source)
+	}
+
+	// Only commands requiring an enforcing kernel are replaced; checkmodule,
+	// semodule_package, and semodule are real and link against the
+	// container's actual policy store, so Stream 9 (no sshd_session_t type)
+	// exercises the fallback path and Stream 10 loads it directly.
+	script := `
+set -euo pipefail
+export SHUNIT_RUNNING=1
+getenforce() { echo Enforcing; }
+restorecon() { :; }
+setsebool() { :; }
+wget() { cp /app/opkssh.te "$3"; }
+source /app/install-linux.sh
+INSTALL_VERSION=local
+output=$(check_selinux 2>&1)
+echo "$output"
+echo "$output" | grep -Fq 'Installed module for ` + tt.expectedPolicyType + `'
+`
+	runSELinuxContainerCommand(t, container, script)
+}
+
+func runSELinuxContainerCommand(t *testing.T, container testcontainers.Container, script string) {
+	t.Helper()
+	exitCode, reader, err := container.Exec(context.Background(), []string{"/bin/bash", "-c", script})
+	require.NoError(t, err, "run command in SELinux test container")
+	output, err := readAllFromReader(reader)
+	require.NoError(t, err, "read SELinux test command output")
+	require.Equalf(t, 0, exitCode, "SELinux test command failed:\n%s", output)
+}


### PR DESCRIPTION
opkssh.te only grants permissions to the sshd_t domain, and install-linux.sh always builds/loads the module for sshd_t unconditionally. Some SELinux policies instead run sshd's AuthorizedKeysCommand under sshd_session_t, so on those systems the installed policy denies opkssh the access it needs.

install-linux.sh now tries loading the module against sshd_session_t first; if the target's loaded policy doesn't define that type, the load fails and it falls back to the sshd_t module. The choice is based on what the loaded policy actually supports, so it works across distros/versions without hardcoding any of them.

Fixes: #599